### PR TITLE
consistent types in results

### DIFF
--- a/tests/actus-tests-ann.json
+++ b/tests/actus-tests-ann.json
@@ -30,203 +30,203 @@
         "results": [ {
             "eventDate" : "2013-01-01T00:00",
             "eventType" : "IED",
-            "payoff" : "-5000.0",
+            "payoff": -5000.0,
             "currency" : "USD",
-            "notionalPrincipal" : "5000.0",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 5000.0,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2013-02-01T00:00",
             "eventType" : "PR",
-            "payoff" : "400.8939913786",
+            "payoff": 400.8939913786,
             "currency" : "USD",
-            "notionalPrincipal" : "4599.1060086213",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "33.9726027397"
+            "notionalPrincipal": 4599.1060086213,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 33.9726027397
         }, {
             "eventDate" : "2013-02-01T00:00",
             "eventType" : "IP",
-            "payoff" : "33.9726027397",
+            "payoff": 33.9726027397,
             "currency" : "USD",
-            "notionalPrincipal" : "4599.1060086213",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 4599.1060086213,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2013-03-01T00:00",
             "eventType" : "PR",
-            "payoff" : "406.6419435448",
+            "payoff": 406.6419435448,
             "currency" : "USD",
-            "notionalPrincipal" : "4192.4640650764",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "28.2246505734"
+            "notionalPrincipal": 4192.4640650764,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 28.2246505734
         }, {
             "eventDate" : "2013-03-01T00:00",
             "eventType" : "IP",
-            "payoff" : "28.2246505734",
+            "payoff": 28.2246505734,
             "currency" : "USD",
-            "notionalPrincipal" : "4192.4640650764",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 4192.4640650764,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2013-04-01T00:00",
             "eventType" : "PR",
-            "payoff" : "406.3808108816",
+            "payoff": 406.3808108816,
             "currency" : "USD",
-            "notionalPrincipal" : "3786.0832541948",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "28.4857832366"
+            "notionalPrincipal": 3786.0832541948,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 28.4857832366
         }, {
             "eventDate" : "2013-04-01T00:00",
             "eventType" : "IP",
-            "payoff" : "28.4857832366",
+            "payoff": 28.4857832366,
             "currency" : "USD",
-            "notionalPrincipal" : "3786.0832541948",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 3786.0832541948,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2013-05-01T00:00",
             "eventType" : "PR",
-            "payoff" : "409.9718001181",
+            "payoff": 409.9718001181,
             "currency" : "USD",
-            "notionalPrincipal" : "3376.1114540766",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "24.8947940001"
+            "notionalPrincipal": 3376.1114540766,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 24.8947940001
         }, {
             "eventDate" : "2013-05-01T00:00",
             "eventType" : "IP",
-            "payoff" : "24.8947940001",
+            "payoff": 24.8947940001,
             "currency" : "USD",
-            "notionalPrincipal" : "3376.1114540766",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 3376.1114540766,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2013-06-01T00:00",
             "eventType" : "PR",
-            "payoff" : "411.9275354714",
+            "payoff": 411.9275354714,
             "currency" : "USD",
-            "notionalPrincipal" : "2964.1839186051",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "22.9390586468"
+            "notionalPrincipal": 2964.1839186051,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 22.9390586468
         }, {
             "eventDate" : "2013-06-01T00:00",
             "eventType" : "IP",
-            "payoff" : "22.9390586468",
+            "payoff": 22.9390586468,
             "currency" : "USD",
-            "notionalPrincipal" : "2964.1839186051",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 2964.1839186051,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2013-07-01T00:00",
             "eventType" : "PR",
-            "payoff" : "415.376069722",
+            "payoff": 415.376069722,
             "currency" : "USD",
-            "notionalPrincipal" : "2548.8078488831",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "19.4905243963"
+            "notionalPrincipal": 2548.8078488831,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 19.4905243963
         }, {
             "eventDate" : "2013-07-01T00:00",
             "eventType" : "IP",
-            "payoff" : "19.4905243963",
+            "payoff": 19.4905243963,
             "currency" : "USD",
-            "notionalPrincipal" : "2548.8078488831",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 2548.8078488831,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2013-08-01T00:00",
             "eventType" : "PR",
-            "payoff" : "417.5486668163",
+            "payoff": 417.5486668163,
             "currency" : "USD",
-            "notionalPrincipal" : "2131.2591820668",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "17.317927302"
+            "notionalPrincipal": 2131.2591820668,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 17.317927302
         }, {
             "eventDate" : "2013-08-01T00:00",
             "eventType" : "IP",
-            "payoff" : "17.317927302",
+            "payoff": 17.317927302,
             "currency" : "USD",
-            "notionalPrincipal" : "2131.2591820668",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 2131.2591820668,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2013-09-01T00:00",
             "eventType" : "PR",
-            "payoff" : "420.3857098127",
+            "payoff": 420.3857098127,
             "currency" : "USD",
-            "notionalPrincipal" : "1710.873472254",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "14.4808843055"
+            "notionalPrincipal": 1710.873472254,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 14.4808843055
         }, {
             "eventDate" : "2013-09-01T00:00",
             "eventType" : "IP",
-            "payoff" : "14.4808843055",
+            "payoff": 14.4808843055,
             "currency" : "USD",
-            "notionalPrincipal" : "1710.873472254",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 1710.873472254,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2013-10-01T00:00",
             "eventType" : "PR",
-            "payoff" : "423.6170151227",
+            "payoff": 423.6170151227,
             "currency" : "USD",
-            "notionalPrincipal" : "1287.2564571313",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "11.2495789956"
+            "notionalPrincipal": 1287.2564571313,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 11.2495789956
         }, {
             "eventDate" : "2013-10-01T00:00",
             "eventType" : "IP",
-            "payoff" : "11.2495789956",
+            "payoff": 11.2495789956,
             "currency" : "USD",
-            "notionalPrincipal" : "1287.2564571313",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 1287.2564571313,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2013-11-01T00:00",
             "eventType" : "PR",
-            "payoff" : "426.1203036698",
+            "payoff": 426.1203036698,
             "currency" : "USD",
-            "notionalPrincipal" : "861.1361534614",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "8.7462904484"
+            "notionalPrincipal": 861.1361534614,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 8.7462904484
         }, {
             "eventDate" : "2013-11-01T00:00",
             "eventType" : "IP",
-            "payoff" : "8.7462904484",
+            "payoff": 8.7462904484,
             "currency" : "USD",
-            "notionalPrincipal" : "861.1361534614",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 861.1361534614,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2013-12-01T00:00",
             "eventType" : "PR",
-            "payoff" : "429.2043289996",
+            "payoff": 429.2043289996,
             "currency" : "USD",
-            "notionalPrincipal" : "431.9318244617",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "5.6622651186"
+            "notionalPrincipal": 431.9318244617,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 5.6622651186
         }, {
             "eventDate" : "2013-12-01T00:00",
             "eventType" : "IP",
-            "payoff" : "5.6622651186",
+            "payoff": 5.6622651186,
             "currency" : "USD",
-            "notionalPrincipal" : "431.9318244617",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 431.9318244617,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2014-01-01T00:00",
             "eventType" : "IP",
-            "payoff" : "2.9347696566",
+            "payoff": 2.9347696566,
             "currency" : "USD",
-            "notionalPrincipal" : "431.9318244617",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 431.9318244617,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2014-01-01T00:00",
             "eventType" : "MD",
-            "payoff" : "431.9318244617",
+            "payoff": 431.9318244617,
             "currency" : "USD",
-            "notionalPrincipal" : "0.0",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 0.0,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 0.0
         } ]    },
     "ann02": {
         "identifier": "ann02",
@@ -259,1931 +259,1931 @@
         "results": [ {
             "eventDate" : "2013-01-01T00:00",
             "eventType" : "IED",
-            "payoff" : "-100000.0",
+            "payoff": -100000.0,
             "currency" : "USD",
-            "notionalPrincipal" : "100000.0",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 100000.0,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2013-02-01T00:00",
             "eventType" : "PR",
-            "payoff" : "577.7514588529",
+            "payoff": 577.7514588529,
             "currency" : "USD",
-            "notionalPrincipal" : "99422.2485411471",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "583.3333333333"
+            "notionalPrincipal": 99422.2485411471,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 583.3333333333
         }, {
             "eventDate" : "2013-02-01T00:00",
             "eventType" : "IP",
-            "payoff" : "583.3333333333",
+            "payoff": 583.3333333333,
             "currency" : "USD",
-            "notionalPrincipal" : "99422.2485411471",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 99422.2485411471,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2013-03-01T00:00",
             "eventType" : "PR",
-            "payoff" : "581.1216756962",
+            "payoff": 581.1216756962,
             "currency" : "USD",
-            "notionalPrincipal" : "98841.1268654508",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "579.96311649"
+            "notionalPrincipal": 98841.1268654508,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 579.96311649
         }, {
             "eventDate" : "2013-03-01T00:00",
             "eventType" : "IP",
-            "payoff" : "579.96311649",
+            "payoff": 579.96311649,
             "currency" : "USD",
-            "notionalPrincipal" : "98841.1268654508",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 98841.1268654508,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2013-04-01T00:00",
             "eventType" : "PR",
-            "payoff" : "584.5115521377",
+            "payoff": 584.5115521377,
             "currency" : "USD",
-            "notionalPrincipal" : "98256.6153133131",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "576.5732400484"
+            "notionalPrincipal": 98256.6153133131,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 576.5732400484
         }, {
             "eventDate" : "2013-04-01T00:00",
             "eventType" : "IP",
-            "payoff" : "576.5732400484",
+            "payoff": 576.5732400484,
             "currency" : "USD",
-            "notionalPrincipal" : "98256.6153133131",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 98256.6153133131,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2013-05-01T00:00",
             "eventType" : "PR",
-            "payoff" : "587.9212028585",
+            "payoff": 587.9212028585,
             "currency" : "USD",
-            "notionalPrincipal" : "97668.6941104545",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "573.1635893276"
+            "notionalPrincipal": 97668.6941104545,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 573.1635893276
         }, {
             "eventDate" : "2013-05-01T00:00",
             "eventType" : "IP",
-            "payoff" : "573.1635893276",
+            "payoff": 573.1635893276,
             "currency" : "USD",
-            "notionalPrincipal" : "97668.6941104545",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 97668.6941104545,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2013-06-01T00:00",
             "eventType" : "PR",
-            "payoff" : "591.3507432085",
+            "payoff": 591.3507432085,
             "currency" : "USD",
-            "notionalPrincipal" : "97077.3433672459",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "569.7340489776"
+            "notionalPrincipal": 97077.3433672459,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 569.7340489776
         }, {
             "eventDate" : "2013-06-01T00:00",
             "eventType" : "IP",
-            "payoff" : "569.7340489776",
+            "payoff": 569.7340489776,
             "currency" : "USD",
-            "notionalPrincipal" : "97077.3433672459",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 97077.3433672459,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2013-07-01T00:00",
             "eventType" : "PR",
-            "payoff" : "594.8002892106",
+            "payoff": 594.8002892106,
             "currency" : "USD",
-            "notionalPrincipal" : "96482.5430780353",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "566.2845029756"
+            "notionalPrincipal": 96482.5430780353,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 566.2845029756
         }, {
             "eventDate" : "2013-07-01T00:00",
             "eventType" : "IP",
-            "payoff" : "566.2845029756",
+            "payoff": 566.2845029756,
             "currency" : "USD",
-            "notionalPrincipal" : "96482.5430780353",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 96482.5430780353,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2013-08-01T00:00",
             "eventType" : "PR",
-            "payoff" : "598.2699575643",
+            "payoff": 598.2699575643,
             "currency" : "USD",
-            "notionalPrincipal" : "95884.2731204709",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "562.8148346218"
+            "notionalPrincipal": 95884.2731204709,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 562.8148346218
         }, {
             "eventDate" : "2013-08-01T00:00",
             "eventType" : "IP",
-            "payoff" : "562.8148346218",
+            "payoff": 562.8148346218,
             "currency" : "USD",
-            "notionalPrincipal" : "95884.2731204709",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 95884.2731204709,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2013-09-01T00:00",
             "eventType" : "PR",
-            "payoff" : "601.7598656501",
+            "payoff": 601.7598656501,
             "currency" : "USD",
-            "notionalPrincipal" : "95282.5132548207",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "559.324926536"
+            "notionalPrincipal": 95282.5132548207,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 559.324926536
         }, {
             "eventDate" : "2013-09-01T00:00",
             "eventType" : "IP",
-            "payoff" : "559.324926536",
+            "payoff": 559.324926536,
             "currency" : "USD",
-            "notionalPrincipal" : "95282.5132548207",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 95282.5132548207,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2013-10-01T00:00",
             "eventType" : "PR",
-            "payoff" : "605.2701315331",
+            "payoff": 605.2701315331,
             "currency" : "USD",
-            "notionalPrincipal" : "94677.2431232876",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "555.8146606531"
+            "notionalPrincipal": 94677.2431232876,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 555.8146606531
         }, {
             "eventDate" : "2013-10-01T00:00",
             "eventType" : "IP",
-            "payoff" : "555.8146606531",
+            "payoff": 555.8146606531,
             "currency" : "USD",
-            "notionalPrincipal" : "94677.2431232876",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 94677.2431232876,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2013-11-01T00:00",
             "eventType" : "PR",
-            "payoff" : "608.800873967",
+            "payoff": 608.800873967,
             "currency" : "USD",
-            "notionalPrincipal" : "94068.4422493206",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "552.2839182191"
+            "notionalPrincipal": 94068.4422493206,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 552.2839182191
         }, {
             "eventDate" : "2013-11-01T00:00",
             "eventType" : "IP",
-            "payoff" : "552.2839182191",
+            "payoff": 552.2839182191,
             "currency" : "USD",
-            "notionalPrincipal" : "94068.4422493206",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 94068.4422493206,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2013-12-01T00:00",
             "eventType" : "PR",
-            "payoff" : "612.3522123985",
+            "payoff": 612.3522123985,
             "currency" : "USD",
-            "notionalPrincipal" : "93456.090036922",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "548.7325797877"
+            "notionalPrincipal": 93456.090036922,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 548.7325797877
         }, {
             "eventDate" : "2013-12-01T00:00",
             "eventType" : "IP",
-            "payoff" : "548.7325797877",
+            "payoff": 548.7325797877,
             "currency" : "USD",
-            "notionalPrincipal" : "93456.090036922",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 93456.090036922,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2014-01-01T00:00",
             "eventType" : "PR",
-            "payoff" : "615.9242669708",
+            "payoff": 615.9242669708,
             "currency" : "USD",
-            "notionalPrincipal" : "92840.1657699512",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "545.1605252153"
+            "notionalPrincipal": 92840.1657699512,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 545.1605252153
         }, {
             "eventDate" : "2014-01-01T00:00",
             "eventType" : "IP",
-            "payoff" : "545.1605252153",
+            "payoff": 545.1605252153,
             "currency" : "USD",
-            "notionalPrincipal" : "92840.1657699512",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 92840.1657699512,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2014-02-01T00:00",
             "eventType" : "PR",
-            "payoff" : "619.5171585281",
+            "payoff": 619.5171585281,
             "currency" : "USD",
-            "notionalPrincipal" : "92220.648611423",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "541.567633658"
+            "notionalPrincipal": 92220.648611423,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 541.567633658
         }, {
             "eventDate" : "2014-02-01T00:00",
             "eventType" : "IP",
-            "payoff" : "541.567633658",
+            "payoff": 541.567633658,
             "currency" : "USD",
-            "notionalPrincipal" : "92220.648611423",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 92220.648611423,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2014-03-01T00:00",
             "eventType" : "PR",
-            "payoff" : "623.1310086196",
+            "payoff": 623.1310086196,
             "currency" : "USD",
-            "notionalPrincipal" : "91597.5176028034",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "537.9537835666"
+            "notionalPrincipal": 91597.5176028034,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 537.9537835666
         }, {
             "eventDate" : "2014-03-01T00:00",
             "eventType" : "IP",
-            "payoff" : "537.9537835666",
+            "payoff": 537.9537835666,
             "currency" : "USD",
-            "notionalPrincipal" : "91597.5176028034",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 91597.5176028034,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2014-04-01T00:00",
             "eventType" : "PR",
-            "payoff" : "626.7659395032",
+            "payoff": 626.7659395032,
             "currency" : "USD",
-            "notionalPrincipal" : "90970.7516633001",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "534.318852683"
+            "notionalPrincipal": 90970.7516633001,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 534.318852683
         }, {
             "eventDate" : "2014-04-01T00:00",
             "eventType" : "IP",
-            "payoff" : "534.318852683",
+            "payoff": 534.318852683,
             "currency" : "USD",
-            "notionalPrincipal" : "90970.7516633001",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 90970.7516633001,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2014-05-01T00:00",
             "eventType" : "PR",
-            "payoff" : "630.4220741503",
+            "payoff": 630.4220741503,
             "currency" : "USD",
-            "notionalPrincipal" : "90340.3295891498",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "530.6627180359"
+            "notionalPrincipal": 90340.3295891498,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 530.6627180359
         }, {
             "eventDate" : "2014-05-01T00:00",
             "eventType" : "IP",
-            "payoff" : "530.6627180359",
+            "payoff": 530.6627180359,
             "currency" : "USD",
-            "notionalPrincipal" : "90340.3295891498",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 90340.3295891498,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2014-06-01T00:00",
             "eventType" : "PR",
-            "payoff" : "634.0995362495",
+            "payoff": 634.0995362495,
             "currency" : "USD",
-            "notionalPrincipal" : "89706.2300529003",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "526.9852559367"
+            "notionalPrincipal": 89706.2300529003,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 526.9852559367
         }, {
             "eventDate" : "2014-06-01T00:00",
             "eventType" : "IP",
-            "payoff" : "526.9852559367",
+            "payoff": 526.9852559367,
             "currency" : "USD",
-            "notionalPrincipal" : "89706.2300529003",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 89706.2300529003,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2014-07-01T00:00",
             "eventType" : "PR",
-            "payoff" : "637.7984502109",
+            "payoff": 637.7984502109,
             "currency" : "USD",
-            "notionalPrincipal" : "89068.4316026893",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "523.2863419752"
+            "notionalPrincipal": 89068.4316026893,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 523.2863419752
         }, {
             "eventDate" : "2014-07-01T00:00",
             "eventType" : "IP",
-            "payoff" : "523.2863419752",
+            "payoff": 523.2863419752,
             "currency" : "USD",
-            "notionalPrincipal" : "89068.4316026893",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 89068.4316026893,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2014-08-01T00:00",
             "eventType" : "PR",
-            "payoff" : "641.5189411705",
+            "payoff": 641.5189411705,
             "currency" : "USD",
-            "notionalPrincipal" : "88426.9126615187",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "519.5658510156"
+            "notionalPrincipal": 88426.9126615187,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 519.5658510156
         }, {
             "eventDate" : "2014-08-01T00:00",
             "eventType" : "IP",
-            "payoff" : "519.5658510156",
+            "payoff": 519.5658510156,
             "currency" : "USD",
-            "notionalPrincipal" : "88426.9126615187",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 88426.9126615187,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2014-09-01T00:00",
             "eventType" : "PR",
-            "payoff" : "645.261134994",
+            "payoff": 645.261134994,
             "currency" : "USD",
-            "notionalPrincipal" : "87781.6515265247",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "515.8236571921"
+            "notionalPrincipal": 87781.6515265247,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 515.8236571921
         }, {
             "eventDate" : "2014-09-01T00:00",
             "eventType" : "IP",
-            "payoff" : "515.8236571921",
+            "payoff": 515.8236571921,
             "currency" : "USD",
-            "notionalPrincipal" : "87781.6515265247",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 87781.6515265247,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2014-10-01T00:00",
             "eventType" : "PR",
-            "payoff" : "649.0251582815",
+            "payoff": 649.0251582815,
             "currency" : "USD",
-            "notionalPrincipal" : "87132.6263682432",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "512.0596339047"
+            "notionalPrincipal": 87132.6263682432,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 512.0596339047
         }, {
             "eventDate" : "2014-10-01T00:00",
             "eventType" : "IP",
-            "payoff" : "512.0596339047",
+            "payoff": 512.0596339047,
             "currency" : "USD",
-            "notionalPrincipal" : "87132.6263682432",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 87132.6263682432,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2014-11-01T00:00",
             "eventType" : "PR",
-            "payoff" : "652.8111383714",
+            "payoff": 652.8111383714,
             "currency" : "USD",
-            "notionalPrincipal" : "86479.8152298717",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "508.2736538147"
+            "notionalPrincipal": 86479.8152298717,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 508.2736538147
         }, {
             "eventDate" : "2014-11-01T00:00",
             "eventType" : "IP",
-            "payoff" : "508.2736538147",
+            "payoff": 508.2736538147,
             "currency" : "USD",
-            "notionalPrincipal" : "86479.8152298717",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 86479.8152298717,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2014-12-01T00:00",
             "eventType" : "PR",
-            "payoff" : "656.6192033453",
+            "payoff": 656.6192033453,
             "currency" : "USD",
-            "notionalPrincipal" : "85823.1960265264",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "504.4655888409"
+            "notionalPrincipal": 85823.1960265264,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 504.4655888409
         }, {
             "eventDate" : "2014-12-01T00:00",
             "eventType" : "IP",
-            "payoff" : "504.4655888409",
+            "payoff": 504.4655888409,
             "currency" : "USD",
-            "notionalPrincipal" : "85823.1960265264",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 85823.1960265264,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2015-01-01T00:00",
             "eventType" : "PR",
-            "payoff" : "660.4494820315",
+            "payoff": 660.4494820315,
             "currency" : "USD",
-            "notionalPrincipal" : "85162.7465444949",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "500.6353101547"
+            "notionalPrincipal": 85162.7465444949,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 500.6353101547
         }, {
             "eventDate" : "2015-01-01T00:00",
             "eventType" : "IP",
-            "payoff" : "500.6353101547",
+            "payoff": 500.6353101547,
             "currency" : "USD",
-            "notionalPrincipal" : "85162.7465444949",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 85162.7465444949,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2015-02-01T00:00",
             "eventType" : "PR",
-            "payoff" : "664.30210401",
+            "payoff": 664.30210401,
             "currency" : "USD",
-            "notionalPrincipal" : "84498.4444404849",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "496.7826881762"
+            "notionalPrincipal": 84498.4444404849,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 496.7826881762
         }, {
             "eventDate" : "2015-02-01T00:00",
             "eventType" : "IP",
-            "payoff" : "496.7826881762",
+            "payoff": 496.7826881762,
             "currency" : "USD",
-            "notionalPrincipal" : "84498.4444404849",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 84498.4444404849,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2015-03-01T00:00",
             "eventType" : "PR",
-            "payoff" : "668.1771996167",
+            "payoff": 668.1771996167,
             "currency" : "USD",
-            "notionalPrincipal" : "83830.2672408681",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "492.9075925694"
+            "notionalPrincipal": 83830.2672408681,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 492.9075925694
         }, {
             "eventDate" : "2015-03-01T00:00",
             "eventType" : "IP",
-            "payoff" : "492.9075925694",
+            "payoff": 492.9075925694,
             "currency" : "USD",
-            "notionalPrincipal" : "83830.2672408681",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 83830.2672408681,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2015-04-01T00:00",
             "eventType" : "PR",
-            "payoff" : "672.0748999478",
+            "payoff": 672.0748999478,
             "currency" : "USD",
-            "notionalPrincipal" : "83158.1923409203",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "489.0098922383"
+            "notionalPrincipal": 83158.1923409203,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 489.0098922383
         }, {
             "eventDate" : "2015-04-01T00:00",
             "eventType" : "IP",
-            "payoff" : "489.0098922383",
+            "payoff": 489.0098922383,
             "currency" : "USD",
-            "notionalPrincipal" : "83158.1923409203",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 83158.1923409203,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2015-05-01T00:00",
             "eventType" : "PR",
-            "payoff" : "675.9953368642",
+            "payoff": 675.9953368642,
             "currency" : "USD",
-            "notionalPrincipal" : "82482.1970040561",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "485.089455322"
+            "notionalPrincipal": 82482.1970040561,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 485.089455322
         }, {
             "eventDate" : "2015-05-01T00:00",
             "eventType" : "IP",
-            "payoff" : "485.089455322",
+            "payoff": 485.089455322,
             "currency" : "USD",
-            "notionalPrincipal" : "82482.1970040561",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 82482.1970040561,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2015-06-01T00:00",
             "eventType" : "PR",
-            "payoff" : "679.9386429959",
+            "payoff": 679.9386429959,
             "currency" : "USD",
-            "notionalPrincipal" : "81802.2583610602",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "481.1461491903"
+            "notionalPrincipal": 81802.2583610602,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 481.1461491903
         }, {
             "eventDate" : "2015-06-01T00:00",
             "eventType" : "IP",
-            "payoff" : "481.1461491903",
+            "payoff": 481.1461491903,
             "currency" : "USD",
-            "notionalPrincipal" : "81802.2583610602",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 81802.2583610602,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2015-07-01T00:00",
             "eventType" : "PR",
-            "payoff" : "683.9049517467",
+            "payoff": 683.9049517467,
             "currency" : "USD",
-            "notionalPrincipal" : "81118.3534093134",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "477.1798404395"
+            "notionalPrincipal": 81118.3534093134,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 477.1798404395
         }, {
             "eventDate" : "2015-07-01T00:00",
             "eventType" : "IP",
-            "payoff" : "477.1798404395",
+            "payoff": 477.1798404395,
             "currency" : "USD",
-            "notionalPrincipal" : "81118.3534093134",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 81118.3534093134,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2015-08-01T00:00",
             "eventType" : "PR",
-            "payoff" : "687.8943972985",
+            "payoff": 687.8943972985,
             "currency" : "USD",
-            "notionalPrincipal" : "80430.4590120149",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "473.1903948876"
+            "notionalPrincipal": 80430.4590120149,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 473.1903948876
         }, {
             "eventDate" : "2015-08-01T00:00",
             "eventType" : "IP",
-            "payoff" : "473.1903948876",
+            "payoff": 473.1903948876,
             "currency" : "USD",
-            "notionalPrincipal" : "80430.4590120149",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 80430.4590120149,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2015-09-01T00:00",
             "eventType" : "PR",
-            "payoff" : "691.9071146161",
+            "payoff": 691.9071146161,
             "currency" : "USD",
-            "notionalPrincipal" : "79738.5518973987",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "469.17767757"
+            "notionalPrincipal": 79738.5518973987,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 469.17767757
         }, {
             "eventDate" : "2015-09-01T00:00",
             "eventType" : "IP",
-            "payoff" : "469.17767757",
+            "payoff": 469.17767757,
             "currency" : "USD",
-            "notionalPrincipal" : "79738.5518973987",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 79738.5518973987,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2015-10-01T00:00",
             "eventType" : "PR",
-            "payoff" : "695.9432394514",
+            "payoff": 695.9432394514,
             "currency" : "USD",
-            "notionalPrincipal" : "79042.6086579473",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "465.1415527348"
+            "notionalPrincipal": 79042.6086579473,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 465.1415527348
         }, {
             "eventDate" : "2015-10-01T00:00",
             "eventType" : "IP",
-            "payoff" : "465.1415527348",
+            "payoff": 465.1415527348,
             "currency" : "USD",
-            "notionalPrincipal" : "79042.6086579473",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 79042.6086579473,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2015-11-01T00:00",
             "eventType" : "PR",
-            "payoff" : "700.0029083482",
+            "payoff": 700.0029083482,
             "currency" : "USD",
-            "notionalPrincipal" : "78342.6057495991",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "461.081883838"
+            "notionalPrincipal": 78342.6057495991,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 461.081883838
         }, {
             "eventDate" : "2015-11-01T00:00",
             "eventType" : "IP",
-            "payoff" : "461.081883838",
+            "payoff": 461.081883838,
             "currency" : "USD",
-            "notionalPrincipal" : "78342.6057495991",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 78342.6057495991,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2015-12-01T00:00",
             "eventType" : "PR",
-            "payoff" : "704.0862586469",
+            "payoff": 704.0862586469,
             "currency" : "USD",
-            "notionalPrincipal" : "77638.5194909522",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "456.9985335393"
+            "notionalPrincipal": 77638.5194909522,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 456.9985335393
         }, {
             "eventDate" : "2015-12-01T00:00",
             "eventType" : "IP",
-            "payoff" : "456.9985335393",
+            "payoff": 456.9985335393,
             "currency" : "USD",
-            "notionalPrincipal" : "77638.5194909522",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 77638.5194909522,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2016-01-01T00:00",
             "eventType" : "PR",
-            "payoff" : "708.193428489",
+            "payoff": 708.193428489,
             "currency" : "USD",
-            "notionalPrincipal" : "76930.3260624632",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "452.8913636972"
+            "notionalPrincipal": 76930.3260624632,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 452.8913636972
         }, {
             "eventDate" : "2016-01-01T00:00",
             "eventType" : "IP",
-            "payoff" : "452.8913636972",
+            "payoff": 452.8913636972,
             "currency" : "USD",
-            "notionalPrincipal" : "76930.3260624632",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 76930.3260624632,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2016-02-01T00:00",
             "eventType" : "PR",
-            "payoff" : "712.3245568218",
+            "payoff": 712.3245568218,
             "currency" : "USD",
-            "notionalPrincipal" : "76218.0015056413",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "448.7602353643"
+            "notionalPrincipal": 76218.0015056413,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 448.7602353643
         }, {
             "eventDate" : "2016-02-01T00:00",
             "eventType" : "IP",
-            "payoff" : "448.7602353643",
+            "payoff": 448.7602353643,
             "currency" : "USD",
-            "notionalPrincipal" : "76218.0015056413",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 76218.0015056413,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2016-03-01T00:00",
             "eventType" : "PR",
-            "payoff" : "716.4797834033",
+            "payoff": 716.4797834033,
             "currency" : "USD",
-            "notionalPrincipal" : "75501.5217222379",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "444.6050087829"
+            "notionalPrincipal": 75501.5217222379,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 444.6050087829
         }, {
             "eventDate" : "2016-03-01T00:00",
             "eventType" : "IP",
-            "payoff" : "444.6050087829",
+            "payoff": 444.6050087829,
             "currency" : "USD",
-            "notionalPrincipal" : "75501.5217222379",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 75501.5217222379,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2016-04-01T00:00",
             "eventType" : "PR",
-            "payoff" : "720.6592488065",
+            "payoff": 720.6592488065,
             "currency" : "USD",
-            "notionalPrincipal" : "74780.8624734314",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "440.4255433797"
+            "notionalPrincipal": 74780.8624734314,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 440.4255433797
         }, {
             "eventDate" : "2016-04-01T00:00",
             "eventType" : "IP",
-            "payoff" : "440.4255433797",
+            "payoff": 440.4255433797,
             "currency" : "USD",
-            "notionalPrincipal" : "74780.8624734314",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 74780.8624734314,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2016-05-01T00:00",
             "eventType" : "PR",
-            "payoff" : "724.8630944245",
+            "payoff": 724.8630944245,
             "currency" : "USD",
-            "notionalPrincipal" : "74055.9993790069",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "436.2216977616"
+            "notionalPrincipal": 74055.9993790069,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 436.2216977616
         }, {
             "eventDate" : "2016-05-01T00:00",
             "eventType" : "IP",
-            "payoff" : "436.2216977616",
+            "payoff": 436.2216977616,
             "currency" : "USD",
-            "notionalPrincipal" : "74055.9993790069",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 74055.9993790069,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2016-06-01T00:00",
             "eventType" : "PR",
-            "payoff" : "729.0914624753",
+            "payoff": 729.0914624753,
             "currency" : "USD",
-            "notionalPrincipal" : "73326.9079165315",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "431.9933297108"
+            "notionalPrincipal": 73326.9079165315,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 431.9933297108
         }, {
             "eventDate" : "2016-06-01T00:00",
             "eventType" : "IP",
-            "payoff" : "431.9933297108",
+            "payoff": 431.9933297108,
             "currency" : "USD",
-            "notionalPrincipal" : "73326.9079165315",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 73326.9079165315,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2016-07-01T00:00",
             "eventType" : "PR",
-            "payoff" : "733.3444960064",
+            "payoff": 733.3444960064,
             "currency" : "USD",
-            "notionalPrincipal" : "72593.563420525",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "427.7402961797"
+            "notionalPrincipal": 72593.563420525,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 427.7402961797
         }, {
             "eventDate" : "2016-07-01T00:00",
             "eventType" : "IP",
-            "payoff" : "427.7402961797",
+            "payoff": 427.7402961797,
             "currency" : "USD",
-            "notionalPrincipal" : "72593.563420525",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 72593.563420525,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2016-08-01T00:00",
             "eventType" : "PR",
-            "payoff" : "737.6223388998",
+            "payoff": 737.6223388998,
             "currency" : "USD",
-            "notionalPrincipal" : "71855.9410816252",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "423.4624532863"
+            "notionalPrincipal": 71855.9410816252,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 423.4624532863
         }, {
             "eventDate" : "2016-08-01T00:00",
             "eventType" : "IP",
-            "payoff" : "423.4624532863",
+            "payoff": 423.4624532863,
             "currency" : "USD",
-            "notionalPrincipal" : "71855.9410816252",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 71855.9410816252,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2016-09-01T00:00",
             "eventType" : "PR",
-            "payoff" : "741.9251358767",
+            "payoff": 741.9251358767,
             "currency" : "USD",
-            "notionalPrincipal" : "71114.0159457484",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "419.1596563094"
+            "notionalPrincipal": 71114.0159457484,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 419.1596563094
         }, {
             "eventDate" : "2016-09-01T00:00",
             "eventType" : "IP",
-            "payoff" : "419.1596563094",
+            "payoff": 419.1596563094,
             "currency" : "USD",
-            "notionalPrincipal" : "71114.0159457484",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 71114.0159457484,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2016-10-01T00:00",
             "eventType" : "PR",
-            "payoff" : "746.2530325027",
+            "payoff": 746.2530325027,
             "currency" : "USD",
-            "notionalPrincipal" : "70367.7629132457",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "414.8317596835"
+            "notionalPrincipal": 70367.7629132457,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 414.8317596835
         }, {
             "eventDate" : "2016-10-01T00:00",
             "eventType" : "IP",
-            "payoff" : "414.8317596835",
+            "payoff": 414.8317596835,
             "currency" : "USD",
-            "notionalPrincipal" : "70367.7629132457",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 70367.7629132457,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2016-11-01T00:00",
             "eventType" : "PR",
-            "payoff" : "750.6061751923",
+            "payoff": 750.6061751923,
             "currency" : "USD",
-            "notionalPrincipal" : "69617.1567380534",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "410.4786169939"
+            "notionalPrincipal": 69617.1567380534,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 410.4786169939
         }, {
             "eventDate" : "2016-11-01T00:00",
             "eventType" : "IP",
-            "payoff" : "410.4786169939",
+            "payoff": 410.4786169939,
             "currency" : "USD",
-            "notionalPrincipal" : "69617.1567380534",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 69617.1567380534,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2016-12-01T00:00",
             "eventType" : "PR",
-            "payoff" : "754.9847112142",
+            "payoff": 754.9847112142,
             "currency" : "USD",
-            "notionalPrincipal" : "68862.1720268392",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "406.1000809719"
+            "notionalPrincipal": 68862.1720268392,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 406.1000809719
         }, {
             "eventDate" : "2016-12-01T00:00",
             "eventType" : "IP",
-            "payoff" : "406.1000809719",
+            "payoff": 406.1000809719,
             "currency" : "USD",
-            "notionalPrincipal" : "68862.1720268392",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 68862.1720268392,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2017-01-01T00:00",
             "eventType" : "PR",
-            "payoff" : "759.3887886963",
+            "payoff": 759.3887886963,
             "currency" : "USD",
-            "notionalPrincipal" : "68102.7832381428",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "401.6960034898"
+            "notionalPrincipal": 68102.7832381428,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 401.6960034898
         }, {
             "eventDate" : "2017-01-01T00:00",
             "eventType" : "IP",
-            "payoff" : "401.6960034898",
+            "payoff": 401.6960034898,
             "currency" : "USD",
-            "notionalPrincipal" : "68102.7832381428",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 68102.7832381428,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2017-02-01T00:00",
             "eventType" : "PR",
-            "payoff" : "763.8185566304",
+            "payoff": 763.8185566304,
             "currency" : "USD",
-            "notionalPrincipal" : "67338.9646815124",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "397.2662355558"
+            "notionalPrincipal": 67338.9646815124,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 397.2662355558
         }, {
             "eventDate" : "2017-02-01T00:00",
             "eventType" : "IP",
-            "payoff" : "397.2662355558",
+            "payoff": 397.2662355558,
             "currency" : "USD",
-            "notionalPrincipal" : "67338.9646815124",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 67338.9646815124,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2017-03-01T00:00",
             "eventType" : "PR",
-            "payoff" : "768.2741648774",
+            "payoff": 768.2741648774,
             "currency" : "USD",
-            "notionalPrincipal" : "66570.690516635",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "392.8106273088"
+            "notionalPrincipal": 66570.690516635,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 392.8106273088
         }, {
             "eventDate" : "2017-03-01T00:00",
             "eventType" : "IP",
-            "payoff" : "392.8106273088",
+            "payoff": 392.8106273088,
             "currency" : "USD",
-            "notionalPrincipal" : "66570.690516635",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 66570.690516635,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2017-04-01T00:00",
             "eventType" : "PR",
-            "payoff" : "772.7557641725",
+            "payoff": 772.7557641725,
             "currency" : "USD",
-            "notionalPrincipal" : "65797.9347524624",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "388.3290280137"
+            "notionalPrincipal": 65797.9347524624,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 388.3290280137
         }, {
             "eventDate" : "2017-04-01T00:00",
             "eventType" : "IP",
-            "payoff" : "388.3290280137",
+            "payoff": 388.3290280137,
             "currency" : "USD",
-            "notionalPrincipal" : "65797.9347524624",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 65797.9347524624,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2017-05-01T00:00",
             "eventType" : "PR",
-            "payoff" : "777.2635061302",
+            "payoff": 777.2635061302,
             "currency" : "USD",
-            "notionalPrincipal" : "65020.6712463322",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "383.821286056"
+            "notionalPrincipal": 65020.6712463322,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 383.821286056
         }, {
             "eventDate" : "2017-05-01T00:00",
             "eventType" : "IP",
-            "payoff" : "383.821286056",
+            "payoff": 383.821286056,
             "currency" : "USD",
-            "notionalPrincipal" : "65020.6712463322",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 65020.6712463322,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2017-06-01T00:00",
             "eventType" : "PR",
-            "payoff" : "781.7975432493",
+            "payoff": 781.7975432493,
             "currency" : "USD",
-            "notionalPrincipal" : "64238.8737030829",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "379.2872489369"
+            "notionalPrincipal": 64238.8737030829,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 379.2872489369
         }, {
             "eventDate" : "2017-06-01T00:00",
             "eventType" : "IP",
-            "payoff" : "379.2872489369",
+            "payoff": 379.2872489369,
             "currency" : "USD",
-            "notionalPrincipal" : "64238.8737030829",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 64238.8737030829,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2017-07-01T00:00",
             "eventType" : "PR",
-            "payoff" : "786.3580289182",
+            "payoff": 786.3580289182,
             "currency" : "USD",
-            "notionalPrincipal" : "63452.5156741647",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "374.7267632679"
+            "notionalPrincipal": 63452.5156741647,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 374.7267632679
         }, {
             "eventDate" : "2017-07-01T00:00",
             "eventType" : "IP",
-            "payoff" : "374.7267632679",
+            "payoff": 374.7267632679,
             "currency" : "USD",
-            "notionalPrincipal" : "63452.5156741647",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 63452.5156741647,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2017-08-01T00:00",
             "eventType" : "PR",
-            "payoff" : "790.9451174202",
+            "payoff": 790.9451174202,
             "currency" : "USD",
-            "notionalPrincipal" : "62661.5705567444",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "370.1396747659"
+            "notionalPrincipal": 62661.5705567444,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 370.1396747659
         }, {
             "eventDate" : "2017-08-01T00:00",
             "eventType" : "IP",
-            "payoff" : "370.1396747659",
+            "payoff": 370.1396747659,
             "currency" : "USD",
-            "notionalPrincipal" : "62661.5705567444",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 62661.5705567444,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2017-09-01T00:00",
             "eventType" : "PR",
-            "payoff" : "795.5589639385",
+            "payoff": 795.5589639385,
             "currency" : "USD",
-            "notionalPrincipal" : "61866.0115928058",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "365.5258282476"
+            "notionalPrincipal": 61866.0115928058,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 365.5258282476
         }, {
             "eventDate" : "2017-09-01T00:00",
             "eventType" : "IP",
-            "payoff" : "365.5258282476",
+            "payoff": 365.5258282476,
             "currency" : "USD",
-            "notionalPrincipal" : "61866.0115928058",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 61866.0115928058,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2017-10-01T00:00",
             "eventType" : "PR",
-            "payoff" : "800.1997245615",
+            "payoff": 800.1997245615,
             "currency" : "USD",
-            "notionalPrincipal" : "61065.8118682443",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "360.8850676247"
+            "notionalPrincipal": 61065.8118682443,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 360.8850676247
         }, {
             "eventDate" : "2017-10-01T00:00",
             "eventType" : "IP",
-            "payoff" : "360.8850676247",
+            "payoff": 360.8850676247,
             "currency" : "USD",
-            "notionalPrincipal" : "61065.8118682443",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 61065.8118682443,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2017-11-01T00:00",
             "eventType" : "PR",
-            "payoff" : "804.8675562881",
+            "payoff": 804.8675562881,
             "currency" : "USD",
-            "notionalPrincipal" : "60260.9443119561",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "356.217235898"
+            "notionalPrincipal": 60260.9443119561,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 356.217235898
         }, {
             "eventDate" : "2017-11-01T00:00",
             "eventType" : "IP",
-            "payoff" : "356.217235898",
+            "payoff": 356.217235898,
             "currency" : "USD",
-            "notionalPrincipal" : "60260.9443119561",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 60260.9443119561,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2017-12-01T00:00",
             "eventType" : "PR",
-            "payoff" : "809.5626170331",
+            "payoff": 809.5626170331,
             "currency" : "USD",
-            "notionalPrincipal" : "59451.381694923",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "351.522175153"
+            "notionalPrincipal": 59451.381694923,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 351.522175153
         }, {
             "eventDate" : "2017-12-01T00:00",
             "eventType" : "IP",
-            "payoff" : "351.522175153",
+            "payoff": 351.522175153,
             "currency" : "USD",
-            "notionalPrincipal" : "59451.381694923",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 59451.381694923,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2018-01-01T00:00",
             "eventType" : "PR",
-            "payoff" : "814.2850656325",
+            "payoff": 814.2850656325,
             "currency" : "USD",
-            "notionalPrincipal" : "58637.0966292905",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "346.7997265537"
+            "notionalPrincipal": 58637.0966292905,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 346.7997265537
         }, {
             "eventDate" : "2018-01-01T00:00",
             "eventType" : "IP",
-            "payoff" : "346.7997265537",
+            "payoff": 346.7997265537,
             "currency" : "USD",
-            "notionalPrincipal" : "58637.0966292905",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 58637.0966292905,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2018-02-01T00:00",
             "eventType" : "PR",
-            "payoff" : "819.0350618487",
+            "payoff": 819.0350618487,
             "currency" : "USD",
-            "notionalPrincipal" : "57818.0615674417",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "342.0497303375"
+            "notionalPrincipal": 57818.0615674417,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 342.0497303375
         }, {
             "eventDate" : "2018-02-01T00:00",
             "eventType" : "IP",
-            "payoff" : "342.0497303375",
+            "payoff": 342.0497303375,
             "currency" : "USD",
-            "notionalPrincipal" : "57818.0615674417",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 57818.0615674417,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2018-03-01T00:00",
             "eventType" : "PR",
-            "payoff" : "823.8127663761",
+            "payoff": 823.8127663761,
             "currency" : "USD",
-            "notionalPrincipal" : "56994.2488010656",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "337.27202581"
+            "notionalPrincipal": 56994.2488010656,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 337.27202581
         }, {
             "eventDate" : "2018-03-01T00:00",
             "eventType" : "IP",
-            "payoff" : "337.27202581",
+            "payoff": 337.27202581,
             "currency" : "USD",
-            "notionalPrincipal" : "56994.2488010656",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 56994.2488010656,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2018-04-01T00:00",
             "eventType" : "PR",
-            "payoff" : "828.6183408466",
+            "payoff": 828.6183408466,
             "currency" : "USD",
-            "notionalPrincipal" : "56165.6304602189",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "332.4664513395"
+            "notionalPrincipal": 56165.6304602189,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 332.4664513395
         }, {
             "eventDate" : "2018-04-01T00:00",
             "eventType" : "IP",
-            "payoff" : "332.4664513395",
+            "payoff": 332.4664513395,
             "currency" : "USD",
-            "notionalPrincipal" : "56165.6304602189",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 56165.6304602189,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2018-05-01T00:00",
             "eventType" : "PR",
-            "payoff" : "833.4519478349",
+            "payoff": 833.4519478349,
             "currency" : "USD",
-            "notionalPrincipal" : "55332.1785123839",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "327.6328443512"
+            "notionalPrincipal": 55332.1785123839,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 327.6328443512
         }, {
             "eventDate" : "2018-05-01T00:00",
             "eventType" : "IP",
-            "payoff" : "327.6328443512",
+            "payoff": 327.6328443512,
             "currency" : "USD",
-            "notionalPrincipal" : "55332.1785123839",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 55332.1785123839,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2018-06-01T00:00",
             "eventType" : "PR",
-            "payoff" : "838.313750864",
+            "payoff": 838.313750864,
             "currency" : "USD",
-            "notionalPrincipal" : "54493.8647615199",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "322.7710413222"
+            "notionalPrincipal": 54493.8647615199,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 322.7710413222
         }, {
             "eventDate" : "2018-06-01T00:00",
             "eventType" : "IP",
-            "payoff" : "322.7710413222",
+            "payoff": 322.7710413222,
             "currency" : "USD",
-            "notionalPrincipal" : "54493.8647615199",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 54493.8647615199,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2018-07-01T00:00",
             "eventType" : "PR",
-            "payoff" : "843.2039144107",
+            "payoff": 843.2039144107,
             "currency" : "USD",
-            "notionalPrincipal" : "53650.6608471092",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "317.8808777755"
+            "notionalPrincipal": 53650.6608471092,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 317.8808777755
         }, {
             "eventDate" : "2018-07-01T00:00",
             "eventType" : "IP",
-            "payoff" : "317.8808777755",
+            "payoff": 317.8808777755,
             "currency" : "USD",
-            "notionalPrincipal" : "53650.6608471092",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 53650.6608471092,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2018-08-01T00:00",
             "eventType" : "PR",
-            "payoff" : "848.1226039114",
+            "payoff": 848.1226039114,
             "currency" : "USD",
-            "notionalPrincipal" : "52802.5382431978",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "312.9621882748"
+            "notionalPrincipal": 52802.5382431978,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 312.9621882748
         }, {
             "eventDate" : "2018-08-01T00:00",
             "eventType" : "IP",
-            "payoff" : "312.9621882748",
+            "payoff": 312.9621882748,
             "currency" : "USD",
-            "notionalPrincipal" : "52802.5382431978",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 52802.5382431978,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2018-09-01T00:00",
             "eventType" : "PR",
-            "payoff" : "853.0699857675",
+            "payoff": 853.0699857675,
             "currency" : "USD",
-            "notionalPrincipal" : "51949.4682574302",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "308.0148064186"
+            "notionalPrincipal": 51949.4682574302,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 308.0148064186
         }, {
             "eventDate" : "2018-09-01T00:00",
             "eventType" : "IP",
-            "payoff" : "308.0148064186",
+            "payoff": 308.0148064186,
             "currency" : "USD",
-            "notionalPrincipal" : "51949.4682574302",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 51949.4682574302,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2018-10-01T00:00",
             "eventType" : "PR",
-            "payoff" : "858.0462273512",
+            "payoff": 858.0462273512,
             "currency" : "USD",
-            "notionalPrincipal" : "51091.422030079",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "303.038564835"
+            "notionalPrincipal": 51091.422030079,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 303.038564835
         }, {
             "eventDate" : "2018-10-01T00:00",
             "eventType" : "IP",
-            "payoff" : "303.038564835",
+            "payoff": 303.038564835,
             "currency" : "USD",
-            "notionalPrincipal" : "51091.422030079",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 51091.422030079,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2018-11-01T00:00",
             "eventType" : "PR",
-            "payoff" : "863.0514970107",
+            "payoff": 863.0514970107,
             "currency" : "USD",
-            "notionalPrincipal" : "50228.3705330682",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "298.0332951754"
+            "notionalPrincipal": 50228.3705330682,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 298.0332951754
         }, {
             "eventDate" : "2018-11-01T00:00",
             "eventType" : "IP",
-            "payoff" : "298.0332951754",
+            "payoff": 298.0332951754,
             "currency" : "USD",
-            "notionalPrincipal" : "50228.3705330682",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 50228.3705330682,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2018-12-01T00:00",
             "eventType" : "PR",
-            "payoff" : "868.0859640766",
+            "payoff": 868.0859640766,
             "currency" : "USD",
-            "notionalPrincipal" : "49360.2845689915",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "292.9988281095"
+            "notionalPrincipal": 49360.2845689915,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 292.9988281095
         }, {
             "eventDate" : "2018-12-01T00:00",
             "eventType" : "IP",
-            "payoff" : "292.9988281095",
+            "payoff": 292.9988281095,
             "currency" : "USD",
-            "notionalPrincipal" : "49360.2845689915",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 49360.2845689915,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2019-01-01T00:00",
             "eventType" : "PR",
-            "payoff" : "873.1497988671",
+            "payoff": 873.1497988671,
             "currency" : "USD",
-            "notionalPrincipal" : "48487.1347701244",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "287.9349933191"
+            "notionalPrincipal": 48487.1347701244,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 287.9349933191
         }, {
             "eventDate" : "2019-01-01T00:00",
             "eventType" : "IP",
-            "payoff" : "287.9349933191",
+            "payoff": 287.9349933191,
             "currency" : "USD",
-            "notionalPrincipal" : "48487.1347701244",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 48487.1347701244,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2019-02-01T00:00",
             "eventType" : "PR",
-            "payoff" : "878.2431726938",
+            "payoff": 878.2431726938,
             "currency" : "USD",
-            "notionalPrincipal" : "47608.8915974306",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "282.8416194923"
+            "notionalPrincipal": 47608.8915974306,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 282.8416194923
         }, {
             "eventDate" : "2019-02-01T00:00",
             "eventType" : "IP",
-            "payoff" : "282.8416194923",
+            "payoff": 282.8416194923,
             "currency" : "USD",
-            "notionalPrincipal" : "47608.8915974306",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 47608.8915974306,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2019-03-01T00:00",
             "eventType" : "PR",
-            "payoff" : "883.3662578678",
+            "payoff": 883.3662578678,
             "currency" : "USD",
-            "notionalPrincipal" : "46725.5253395627",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "277.7185343183"
+            "notionalPrincipal": 46725.5253395627,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 277.7185343183
         }, {
             "eventDate" : "2019-03-01T00:00",
             "eventType" : "IP",
-            "payoff" : "277.7185343183",
+            "payoff": 277.7185343183,
             "currency" : "USD",
-            "notionalPrincipal" : "46725.5253395627",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 46725.5253395627,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2019-04-01T00:00",
             "eventType" : "PR",
-            "payoff" : "888.5192277054",
+            "payoff": 888.5192277054,
             "currency" : "USD",
-            "notionalPrincipal" : "45837.0061118572",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "272.5655644807"
+            "notionalPrincipal": 45837.0061118572,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 272.5655644807
         }, {
             "eventDate" : "2019-04-01T00:00",
             "eventType" : "IP",
-            "payoff" : "272.5655644807",
+            "payoff": 272.5655644807,
             "currency" : "USD",
-            "notionalPrincipal" : "45837.0061118572",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 45837.0061118572,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2019-05-01T00:00",
             "eventType" : "PR",
-            "payoff" : "893.7022565337",
+            "payoff": 893.7022565337,
             "currency" : "USD",
-            "notionalPrincipal" : "44943.3038553235",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "267.3825356525"
+            "notionalPrincipal": 44943.3038553235,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 267.3825356525
         }, {
             "eventDate" : "2019-05-01T00:00",
             "eventType" : "IP",
-            "payoff" : "267.3825356525",
+            "payoff": 267.3825356525,
             "currency" : "USD",
-            "notionalPrincipal" : "44943.3038553235",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 44943.3038553235,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2019-06-01T00:00",
             "eventType" : "PR",
-            "payoff" : "898.9155196968",
+            "payoff": 898.9155196968,
             "currency" : "USD",
-            "notionalPrincipal" : "44044.3883356266",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "262.1692724893"
+            "notionalPrincipal": 44044.3883356266,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 262.1692724893
         }, {
             "eventDate" : "2019-06-01T00:00",
             "eventType" : "IP",
-            "payoff" : "262.1692724893",
+            "payoff": 262.1692724893,
             "currency" : "USD",
-            "notionalPrincipal" : "44044.3883356266",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 44044.3883356266,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2019-07-01T00:00",
             "eventType" : "PR",
-            "payoff" : "904.1591935617",
+            "payoff": 904.1591935617,
             "currency" : "USD",
-            "notionalPrincipal" : "43140.2291420649",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "256.9255986244"
+            "notionalPrincipal": 43140.2291420649,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 256.9255986244
         }, {
             "eventDate" : "2019-07-01T00:00",
             "eventType" : "IP",
-            "payoff" : "256.9255986244",
+            "payoff": 256.9255986244,
             "currency" : "USD",
-            "notionalPrincipal" : "43140.2291420649",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 43140.2291420649,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2019-08-01T00:00",
             "eventType" : "PR",
-            "payoff" : "909.4334555241",
+            "payoff": 909.4334555241,
             "currency" : "USD",
-            "notionalPrincipal" : "42230.7956865407",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "251.651336662"
+            "notionalPrincipal": 42230.7956865407,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 251.651336662
         }, {
             "eventDate" : "2019-08-01T00:00",
             "eventType" : "IP",
-            "payoff" : "251.651336662",
+            "payoff": 251.651336662,
             "currency" : "USD",
-            "notionalPrincipal" : "42230.7956865407",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 42230.7956865407,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2019-09-01T00:00",
             "eventType" : "PR",
-            "payoff" : "914.7384840147",
+            "payoff": 914.7384840147,
             "currency" : "USD",
-            "notionalPrincipal" : "41316.0572025259",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "246.3463081714"
+            "notionalPrincipal": 41316.0572025259,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 246.3463081714
         }, {
             "eventDate" : "2019-09-01T00:00",
             "eventType" : "IP",
-            "payoff" : "246.3463081714",
+            "payoff": 246.3463081714,
             "currency" : "USD",
-            "notionalPrincipal" : "41316.0572025259",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 41316.0572025259,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2019-10-01T00:00",
             "eventType" : "PR",
-            "payoff" : "920.0744585048",
+            "payoff": 920.0744585048,
             "currency" : "USD",
-            "notionalPrincipal" : "40395.9827440211",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "241.0103336814"
+            "notionalPrincipal": 40395.9827440211,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 241.0103336814
         }, {
             "eventDate" : "2019-10-01T00:00",
             "eventType" : "IP",
-            "payoff" : "241.0103336814",
+            "payoff": 241.0103336814,
             "currency" : "USD",
-            "notionalPrincipal" : "40395.9827440211",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 40395.9827440211,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2019-11-01T00:00",
             "eventType" : "PR",
-            "payoff" : "925.4415595127",
+            "payoff": 925.4415595127,
             "currency" : "USD",
-            "notionalPrincipal" : "39470.5411845083",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "235.6432326734"
+            "notionalPrincipal": 39470.5411845083,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 235.6432326734
         }, {
             "eventDate" : "2019-11-01T00:00",
             "eventType" : "IP",
-            "payoff" : "235.6432326734",
+            "payoff": 235.6432326734,
             "currency" : "USD",
-            "notionalPrincipal" : "39470.5411845083",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 39470.5411845083,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2019-12-01T00:00",
             "eventType" : "PR",
-            "payoff" : "930.8399686099",
+            "payoff": 930.8399686099,
             "currency" : "USD",
-            "notionalPrincipal" : "38539.7012158984",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "230.2448235762"
+            "notionalPrincipal": 38539.7012158984,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 230.2448235762
         }, {
             "eventDate" : "2019-12-01T00:00",
             "eventType" : "IP",
-            "payoff" : "230.2448235762",
+            "payoff": 230.2448235762,
             "currency" : "USD",
-            "notionalPrincipal" : "38539.7012158984",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 38539.7012158984,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2020-01-01T00:00",
             "eventType" : "PR",
-            "payoff" : "936.2698684268",
+            "payoff": 936.2698684268,
             "currency" : "USD",
-            "notionalPrincipal" : "37603.4313474715",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "224.8149237594"
+            "notionalPrincipal": 37603.4313474715,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 224.8149237594
         }, {
             "eventDate" : "2020-01-01T00:00",
             "eventType" : "IP",
-            "payoff" : "224.8149237594",
+            "payoff": 224.8149237594,
             "currency" : "USD",
-            "notionalPrincipal" : "37603.4313474715",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 37603.4313474715,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2020-02-01T00:00",
             "eventType" : "PR",
-            "payoff" : "941.7314426593",
+            "payoff": 941.7314426593,
             "currency" : "USD",
-            "notionalPrincipal" : "36661.6999048122",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "219.3533495269"
+            "notionalPrincipal": 36661.6999048122,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 219.3533495269
         }, {
             "eventDate" : "2020-02-01T00:00",
             "eventType" : "IP",
-            "payoff" : "219.3533495269",
+            "payoff": 219.3533495269,
             "currency" : "USD",
-            "notionalPrincipal" : "36661.6999048122",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 36661.6999048122,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2020-03-01T00:00",
             "eventType" : "PR",
-            "payoff" : "947.2248760748",
+            "payoff": 947.2248760748,
             "currency" : "USD",
-            "notionalPrincipal" : "35714.4750287374",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "213.8599161114"
+            "notionalPrincipal": 35714.4750287374,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 213.8599161114
         }, {
             "eventDate" : "2020-03-01T00:00",
             "eventType" : "IP",
-            "payoff" : "213.8599161114",
+            "payoff": 213.8599161114,
             "currency" : "USD",
-            "notionalPrincipal" : "35714.4750287374",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 35714.4750287374,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2020-04-01T00:00",
             "eventType" : "PR",
-            "payoff" : "952.7503545186",
+            "payoff": 952.7503545186,
             "currency" : "USD",
-            "notionalPrincipal" : "34761.7246742188",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "208.3344376676"
+            "notionalPrincipal": 34761.7246742188,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 208.3344376676
         }, {
             "eventDate" : "2020-04-01T00:00",
             "eventType" : "IP",
-            "payoff" : "208.3344376676",
+            "payoff": 208.3344376676,
             "currency" : "USD",
-            "notionalPrincipal" : "34761.7246742188",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 34761.7246742188,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2020-05-01T00:00",
             "eventType" : "PR",
-            "payoff" : "958.3080649199",
+            "payoff": 958.3080649199,
             "currency" : "USD",
-            "notionalPrincipal" : "33803.4166092988",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "202.7767272662"
+            "notionalPrincipal": 33803.4166092988,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 202.7767272662
         }, {
             "eventDate" : "2020-05-01T00:00",
             "eventType" : "IP",
-            "payoff" : "202.7767272662",
+            "payoff": 202.7767272662,
             "currency" : "USD",
-            "notionalPrincipal" : "33803.4166092988",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 33803.4166092988,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2020-06-01T00:00",
             "eventType" : "PR",
-            "payoff" : "963.8981952986",
+            "payoff": 963.8981952986,
             "currency" : "USD",
-            "notionalPrincipal" : "32839.5184140001",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "197.1865968875"
+            "notionalPrincipal": 32839.5184140001,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 197.1865968875
         }, {
             "eventDate" : "2020-06-01T00:00",
             "eventType" : "IP",
-            "payoff" : "197.1865968875",
+            "payoff": 197.1865968875,
             "currency" : "USD",
-            "notionalPrincipal" : "32839.5184140001",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 32839.5184140001,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2020-07-01T00:00",
             "eventType" : "PR",
-            "payoff" : "969.5209347712",
+            "payoff": 969.5209347712,
             "currency" : "USD",
-            "notionalPrincipal" : "31869.9974792289",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "191.563857415"
+            "notionalPrincipal": 31869.9974792289,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 191.563857415
         }, {
             "eventDate" : "2020-07-01T00:00",
             "eventType" : "IP",
-            "payoff" : "191.563857415",
+            "payoff": 191.563857415,
             "currency" : "USD",
-            "notionalPrincipal" : "31869.9974792289",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 31869.9974792289,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2020-08-01T00:00",
             "eventType" : "PR",
-            "payoff" : "975.1764735574",
+            "payoff": 975.1764735574,
             "currency" : "USD",
-            "notionalPrincipal" : "30894.8210056715",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "185.9083186288"
+            "notionalPrincipal": 30894.8210056715,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 185.9083186288
         }, {
             "eventDate" : "2020-08-01T00:00",
             "eventType" : "IP",
-            "payoff" : "185.9083186288",
+            "payoff": 185.9083186288,
             "currency" : "USD",
-            "notionalPrincipal" : "30894.8210056715",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 30894.8210056715,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2020-09-01T00:00",
             "eventType" : "PR",
-            "payoff" : "980.8650029864",
+            "payoff": 980.8650029864,
             "currency" : "USD",
-            "notionalPrincipal" : "29913.956002685",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "180.2197891997"
+            "notionalPrincipal": 29913.956002685,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 180.2197891997
         }, {
             "eventDate" : "2020-09-01T00:00",
             "eventType" : "IP",
-            "payoff" : "180.2197891997",
+            "payoff": 180.2197891997,
             "currency" : "USD",
-            "notionalPrincipal" : "29913.956002685",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 29913.956002685,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2020-10-01T00:00",
             "eventType" : "PR",
-            "payoff" : "986.5867155039",
+            "payoff": 986.5867155039,
             "currency" : "USD",
-            "notionalPrincipal" : "28927.3692871811",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "174.4980766823"
+            "notionalPrincipal": 28927.3692871811,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 174.4980766823
         }, {
             "eventDate" : "2020-10-01T00:00",
             "eventType" : "IP",
-            "payoff" : "174.4980766823",
+            "payoff": 174.4980766823,
             "currency" : "USD",
-            "notionalPrincipal" : "28927.3692871811",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 28927.3692871811,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2020-11-01T00:00",
             "eventType" : "PR",
-            "payoff" : "992.3418046776",
+            "payoff": 992.3418046776,
             "currency" : "USD",
-            "notionalPrincipal" : "27935.0274825034",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "168.7429875085"
+            "notionalPrincipal": 27935.0274825034,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 168.7429875085
         }, {
             "eventDate" : "2020-11-01T00:00",
             "eventType" : "IP",
-            "payoff" : "168.7429875085",
+            "payoff": 168.7429875085,
             "currency" : "USD",
-            "notionalPrincipal" : "27935.0274825034",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 27935.0274825034,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2020-12-01T00:00",
             "eventType" : "PR",
-            "payoff" : "998.1304652049",
+            "payoff": 998.1304652049,
             "currency" : "USD",
-            "notionalPrincipal" : "26936.8970172984",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "162.9543269812"
+            "notionalPrincipal": 26936.8970172984,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 162.9543269812
         }, {
             "eventDate" : "2020-12-01T00:00",
             "eventType" : "IP",
-            "payoff" : "162.9543269812",
+            "payoff": 162.9543269812,
             "currency" : "USD",
-            "notionalPrincipal" : "26936.8970172984",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 26936.8970172984,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2021-01-01T00:00",
             "eventType" : "PR",
-            "payoff" : "1003.9528929186",
+            "payoff": 1003.9528929186,
             "currency" : "USD",
-            "notionalPrincipal" : "25932.9441243798",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "157.1318992675"
+            "notionalPrincipal": 25932.9441243798,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 157.1318992675
         }, {
             "eventDate" : "2021-01-01T00:00",
             "eventType" : "IP",
-            "payoff" : "157.1318992675",
+            "payoff": 157.1318992675,
             "currency" : "USD",
-            "notionalPrincipal" : "25932.9441243798",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 25932.9441243798,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2021-02-01T00:00",
             "eventType" : "PR",
-            "payoff" : "1009.809284794",
+            "payoff": 1009.809284794,
             "currency" : "USD",
-            "notionalPrincipal" : "24923.1348395857",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "151.2755073922"
+            "notionalPrincipal": 24923.1348395857,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 151.2755073922
         }, {
             "eventDate" : "2021-02-01T00:00",
             "eventType" : "IP",
-            "payoff" : "151.2755073922",
+            "payoff": 151.2755073922,
             "currency" : "USD",
-            "notionalPrincipal" : "24923.1348395857",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 24923.1348395857,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2021-03-01T00:00",
             "eventType" : "PR",
-            "payoff" : "1015.6998389553",
+            "payoff": 1015.6998389553,
             "currency" : "USD",
-            "notionalPrincipal" : "23907.4350006304",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "145.3849532309"
+            "notionalPrincipal": 23907.4350006304,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 145.3849532309
         }, {
             "eventDate" : "2021-03-01T00:00",
             "eventType" : "IP",
-            "payoff" : "145.3849532309",
+            "payoff": 145.3849532309,
             "currency" : "USD",
-            "notionalPrincipal" : "23907.4350006304",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 23907.4350006304,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2021-04-01T00:00",
             "eventType" : "PR",
-            "payoff" : "1021.6247546825",
+            "payoff": 1021.6247546825,
             "currency" : "USD",
-            "notionalPrincipal" : "22885.8102459479",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "139.4600375036"
+            "notionalPrincipal": 22885.8102459479,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 139.4600375036
         }, {
             "eventDate" : "2021-04-01T00:00",
             "eventType" : "IP",
-            "payoff" : "139.4600375036",
+            "payoff": 139.4600375036,
             "currency" : "USD",
-            "notionalPrincipal" : "22885.8102459479",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 22885.8102459479,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2021-05-01T00:00",
             "eventType" : "PR",
-            "payoff" : "1027.5842324182",
+            "payoff": 1027.5842324182,
             "currency" : "USD",
-            "notionalPrincipal" : "21858.2260135296",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "133.500559768"
+            "notionalPrincipal": 21858.2260135296,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 133.500559768
         }, {
             "eventDate" : "2021-05-01T00:00",
             "eventType" : "IP",
-            "payoff" : "133.500559768",
+            "payoff": 133.500559768,
             "currency" : "USD",
-            "notionalPrincipal" : "21858.2260135296",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 21858.2260135296,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2021-06-01T00:00",
             "eventType" : "PR",
-            "payoff" : "1033.5784737739",
+            "payoff": 1033.5784737739,
             "currency" : "USD",
-            "notionalPrincipal" : "20824.6475397557",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "127.5063184122"
+            "notionalPrincipal": 20824.6475397557,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 127.5063184122
         }, {
             "eventDate" : "2021-06-01T00:00",
             "eventType" : "IP",
-            "payoff" : "127.5063184122",
+            "payoff": 127.5063184122,
             "currency" : "USD",
-            "notionalPrincipal" : "20824.6475397557",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 20824.6475397557,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2021-07-01T00:00",
             "eventType" : "PR",
-            "payoff" : "1039.6076815376",
+            "payoff": 1039.6076815376,
             "currency" : "USD",
-            "notionalPrincipal" : "19785.039858218",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "121.4771106485"
+            "notionalPrincipal": 19785.039858218,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 121.4771106485
         }, {
             "eventDate" : "2021-07-01T00:00",
             "eventType" : "IP",
-            "payoff" : "121.4771106485",
+            "payoff": 121.4771106485,
             "currency" : "USD",
-            "notionalPrincipal" : "19785.039858218",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 19785.039858218,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2021-08-01T00:00",
             "eventType" : "PR",
-            "payoff" : "1045.6720596799",
+            "payoff": 1045.6720596799,
             "currency" : "USD",
-            "notionalPrincipal" : "18739.367798538",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "115.4127325062"
+            "notionalPrincipal": 18739.367798538,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 115.4127325062
         }, {
             "eventDate" : "2021-08-01T00:00",
             "eventType" : "IP",
-            "payoff" : "115.4127325062",
+            "payoff": 115.4127325062,
             "currency" : "USD",
-            "notionalPrincipal" : "18739.367798538",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 18739.367798538,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2021-09-01T00:00",
             "eventType" : "PR",
-            "payoff" : "1051.7718133614",
+            "payoff": 1051.7718133614,
             "currency" : "USD",
-            "notionalPrincipal" : "17687.5959851766",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "109.3129788248"
+            "notionalPrincipal": 17687.5959851766,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 109.3129788248
         }, {
             "eventDate" : "2021-09-01T00:00",
             "eventType" : "IP",
-            "payoff" : "109.3129788248",
+            "payoff": 109.3129788248,
             "currency" : "USD",
-            "notionalPrincipal" : "17687.5959851766",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 17687.5959851766,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2021-10-01T00:00",
             "eventType" : "PR",
-            "payoff" : "1057.9071489393",
+            "payoff": 1057.9071489393,
             "currency" : "USD",
-            "notionalPrincipal" : "16629.6888362372",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "103.1776432468"
+            "notionalPrincipal": 16629.6888362372,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 103.1776432468
         }, {
             "eventDate" : "2021-10-01T00:00",
             "eventType" : "IP",
-            "payoff" : "103.1776432468",
+            "payoff": 103.1776432468,
             "currency" : "USD",
-            "notionalPrincipal" : "16629.6888362372",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 16629.6888362372,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2021-11-01T00:00",
             "eventType" : "PR",
-            "payoff" : "1064.0782739748",
+            "payoff": 1064.0782739748,
             "currency" : "USD",
-            "notionalPrincipal" : "15565.6105622624",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "97.0065182113"
+            "notionalPrincipal": 15565.6105622624,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 97.0065182113
         }, {
             "eventDate" : "2021-11-01T00:00",
             "eventType" : "IP",
-            "payoff" : "97.0065182113",
+            "payoff": 97.0065182113,
             "currency" : "USD",
-            "notionalPrincipal" : "15565.6105622624",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 15565.6105622624,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2021-12-01T00:00",
             "eventType" : "PR",
-            "payoff" : "1070.2853972397",
+            "payoff": 1070.2853972397,
             "currency" : "USD",
-            "notionalPrincipal" : "14495.3251650226",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "90.7993949465"
+            "notionalPrincipal": 14495.3251650226,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 90.7993949465
         }, {
             "eventDate" : "2021-12-01T00:00",
             "eventType" : "IP",
-            "payoff" : "90.7993949465",
+            "payoff": 90.7993949465,
             "currency" : "USD",
-            "notionalPrincipal" : "14495.3251650226",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 14495.3251650226,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2022-01-01T00:00",
             "eventType" : "PR",
-            "payoff" : "1076.5287287236",
+            "payoff": 1076.5287287236,
             "currency" : "USD",
-            "notionalPrincipal" : "13418.796436299",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "84.5560634626"
+            "notionalPrincipal": 13418.796436299,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 84.5560634626
         }, {
             "eventDate" : "2022-01-01T00:00",
             "eventType" : "IP",
-            "payoff" : "84.5560634626",
+            "payoff": 84.5560634626,
             "currency" : "USD",
-            "notionalPrincipal" : "13418.796436299",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 13418.796436299,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2022-02-01T00:00",
             "eventType" : "PR",
-            "payoff" : "1082.8084796411",
+            "payoff": 1082.8084796411,
             "currency" : "USD",
-            "notionalPrincipal" : "12335.9879566579",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "78.276312545"
+            "notionalPrincipal": 12335.9879566579,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 78.276312545
         }, {
             "eventDate" : "2022-02-01T00:00",
             "eventType" : "IP",
-            "payoff" : "78.276312545",
+            "payoff": 78.276312545,
             "currency" : "USD",
-            "notionalPrincipal" : "12335.9879566579",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 12335.9879566579,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2022-03-01T00:00",
             "eventType" : "PR",
-            "payoff" : "1089.124862439",
+            "payoff": 1089.124862439,
             "currency" : "USD",
-            "notionalPrincipal" : "11246.8630942188",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "71.9599297471"
+            "notionalPrincipal": 11246.8630942188,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 71.9599297471
         }, {
             "eventDate" : "2022-03-01T00:00",
             "eventType" : "IP",
-            "payoff" : "71.9599297471",
+            "payoff": 71.9599297471,
             "currency" : "USD",
-            "notionalPrincipal" : "11246.8630942188",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 11246.8630942188,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2022-04-01T00:00",
             "eventType" : "PR",
-            "payoff" : "1095.4780908032",
+            "payoff": 1095.4780908032,
             "currency" : "USD",
-            "notionalPrincipal" : "10151.3850034155",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "65.6067013829"
+            "notionalPrincipal": 10151.3850034155,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 65.6067013829
         }, {
             "eventDate" : "2022-04-01T00:00",
             "eventType" : "IP",
-            "payoff" : "65.6067013829",
+            "payoff": 65.6067013829,
             "currency" : "USD",
-            "notionalPrincipal" : "10151.3850034155",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 10151.3850034155,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2022-05-01T00:00",
             "eventType" : "PR",
-            "payoff" : "1101.8683796663",
+            "payoff": 1101.8683796663,
             "currency" : "USD",
-            "notionalPrincipal" : "9049.5166237492",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "59.2164125199"
+            "notionalPrincipal": 9049.5166237492,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 59.2164125199
         }, {
             "eventDate" : "2022-05-01T00:00",
             "eventType" : "IP",
-            "payoff" : "59.2164125199",
+            "payoff": 59.2164125199,
             "currency" : "USD",
-            "notionalPrincipal" : "9049.5166237492",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 9049.5166237492,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2022-06-01T00:00",
             "eventType" : "PR",
-            "payoff" : "1108.2959452143",
+            "payoff": 1108.2959452143,
             "currency" : "USD",
-            "notionalPrincipal" : "7941.2206785348",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "52.7888469718"
+            "notionalPrincipal": 7941.2206785348,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 52.7888469718
         }, {
             "eventDate" : "2022-06-01T00:00",
             "eventType" : "IP",
-            "payoff" : "52.7888469718",
+            "payoff": 52.7888469718,
             "currency" : "USD",
-            "notionalPrincipal" : "7941.2206785348",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 7941.2206785348,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2022-07-01T00:00",
             "eventType" : "PR",
-            "payoff" : "1114.7610048947",
+            "payoff": 1114.7610048947,
             "currency" : "USD",
-            "notionalPrincipal" : "6826.45967364",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "46.3237872914"
+            "notionalPrincipal": 6826.45967364,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 46.3237872914
         }, {
             "eventDate" : "2022-07-01T00:00",
             "eventType" : "IP",
-            "payoff" : "46.3237872914",
+            "payoff": 46.3237872914,
             "currency" : "USD",
-            "notionalPrincipal" : "6826.45967364",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 6826.45967364,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2022-08-01T00:00",
             "eventType" : "PR",
-            "payoff" : "1121.2637774233",
+            "payoff": 1121.2637774233,
             "currency" : "USD",
-            "notionalPrincipal" : "5705.1958962167",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "39.8210147629"
+            "notionalPrincipal": 5705.1958962167,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 39.8210147629
         }, {
             "eventDate" : "2022-08-01T00:00",
             "eventType" : "IP",
-            "payoff" : "39.8210147629",
+            "payoff": 39.8210147629,
             "currency" : "USD",
-            "notionalPrincipal" : "5705.1958962167",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 5705.1958962167,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2022-09-01T00:00",
             "eventType" : "PR",
-            "payoff" : "1127.8044827916",
+            "payoff": 1127.8044827916,
             "currency" : "USD",
-            "notionalPrincipal" : "4577.3914134251",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "33.2803093945"
+            "notionalPrincipal": 4577.3914134251,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 33.2803093945
         }, {
             "eventDate" : "2022-09-01T00:00",
             "eventType" : "IP",
-            "payoff" : "33.2803093945",
+            "payoff": 33.2803093945,
             "currency" : "USD",
-            "notionalPrincipal" : "4577.3914134251",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 4577.3914134251,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2022-10-01T00:00",
             "eventType" : "PR",
-            "payoff" : "1134.3833422745",
+            "payoff": 1134.3833422745,
             "currency" : "USD",
-            "notionalPrincipal" : "3443.0080711505",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "26.7014499116"
+            "notionalPrincipal": 3443.0080711505,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 26.7014499116
         }, {
             "eventDate" : "2022-10-01T00:00",
             "eventType" : "IP",
-            "payoff" : "26.7014499116",
+            "payoff": 26.7014499116,
             "currency" : "USD",
-            "notionalPrincipal" : "3443.0080711505",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 3443.0080711505,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2022-11-01T00:00",
             "eventType" : "PR",
-            "payoff" : "1141.0005784378",
+            "payoff": 1141.0005784378,
             "currency" : "USD",
-            "notionalPrincipal" : "2302.0074927126",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "20.0842137483"
+            "notionalPrincipal": 2302.0074927126,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 20.0842137483
         }, {
             "eventDate" : "2022-11-01T00:00",
             "eventType" : "IP",
-            "payoff" : "20.0842137483",
+            "payoff": 20.0842137483,
             "currency" : "USD",
-            "notionalPrincipal" : "2302.0074927126",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 2302.0074927126,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2022-12-01T00:00",
             "eventType" : "PR",
-            "payoff" : "1147.6564151454",
+            "payoff": 1147.6564151454,
             "currency" : "USD",
-            "notionalPrincipal" : "1154.3510775672",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "13.4283770408"
+            "notionalPrincipal": 1154.3510775672,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 13.4283770408
         }, {
             "eventDate" : "2022-12-01T00:00",
             "eventType" : "IP",
-            "payoff" : "13.4283770408",
+            "payoff": 13.4283770408,
             "currency" : "USD",
-            "notionalPrincipal" : "1154.3510775672",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 1154.3510775672,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2023-01-01T00:00",
             "eventType" : "IP",
-            "payoff" : "6.7337146191",
+            "payoff": 6.7337146191,
             "currency" : "USD",
-            "notionalPrincipal" : "1154.3510775672",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 1154.3510775672,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2023-01-01T00:00",
             "eventType" : "MD",
-            "payoff" : "1154.3510775672",
+            "payoff": 1154.3510775672,
             "currency" : "USD",
-            "notionalPrincipal" : "0.0",
-            "nominalInterestRate" : "0.07",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 0.0,
+            "nominalInterestRate": 0.07,
+            "accruedInterest": 0.0
         } ]    },
     "ann03": {
         "identifier": "ann03",
@@ -2217,245 +2217,245 @@
             {
                 "eventDate": "2013-01-01T00:00",
                 "eventType": "IED",
-                "payoff": "-5000.0",
+                "payoff": -5000.0,
                 "currency": "USD",
-                "notionalPrincipal": "5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-01-01T00:00",
                 "eventType": "PR",
-                "payoff": "400.071084163282",
+                "payoff": 400.071084163282,
                 "currency": "USD",
-                "notionalPrincipal": "4599.92891583672",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4599.92891583672,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-01-01T00:00",
                 "eventType": "IP",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "4599.92891583672",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4599.92891583672,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "PR",
-                "payoff": "368.816772625542",
+                "payoff": 368.816772625542,
                 "currency": "USD",
-                "notionalPrincipal": "4231.11214321118",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "31.2543115377399"
+                "notionalPrincipal": 4231.11214321118,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 31.2543115377399
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "IP",
-                "payoff": "31.2543115377399",
+                "payoff": 31.2543115377399,
                 "currency": "USD",
-                "notionalPrincipal": "4231.11214321118",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4231.11214321118,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "PR",
-                "payoff": "374.104806900835",
+                "payoff": 374.104806900835,
                 "currency": "USD",
-                "notionalPrincipal": "3857.00733631034",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "25.9662772624467"
+                "notionalPrincipal": 3857.00733631034,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 25.9662772624467
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "IP",
-                "payoff": "25.9662772624467",
+                "payoff": 25.9662772624467,
                 "currency": "USD",
-                "notionalPrincipal": "3857.00733631034",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3857.00733631034,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "PR",
-                "payoff": "373.864568563146",
+                "payoff": 373.864568563146,
                 "currency": "USD",
-                "notionalPrincipal": "3483.14276774719",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "26.206515600136"
+                "notionalPrincipal": 3483.14276774719,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 26.206515600136
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "IP",
-                "payoff": "26.206515600136",
+                "payoff": 26.206515600136,
                 "currency": "USD",
-                "notionalPrincipal": "3483.14276774719",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3483.14276774719,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "PR",
-                "payoff": "377.168227608232",
+                "payoff": 377.168227608232,
                 "currency": "USD",
-                "notionalPrincipal": "3105.97454013896",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "22.90285655505"
+                "notionalPrincipal": 3105.97454013896,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 22.90285655505
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "IP",
-                "payoff": "22.90285655505",
+                "payoff": 22.90285655505,
                 "currency": "USD",
-                "notionalPrincipal": "3105.97454013896",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3105.97454013896,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "PR",
-                "payoff": "378.967476328913",
+                "payoff": 378.967476328913,
                 "currency": "USD",
-                "notionalPrincipal": "2727.00706381005",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "21.1036078343689"
+                "notionalPrincipal": 2727.00706381005,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 21.1036078343689
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "IP",
-                "payoff": "21.1036078343689",
+                "payoff": 21.1036078343689,
                 "currency": "USD",
-                "notionalPrincipal": "2727.00706381005",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2727.00706381005,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "PR",
-                "payoff": "382.140078812202",
+                "payoff": 382.140078812202,
                 "currency": "USD",
-                "notionalPrincipal": "2344.86698499785",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "17.9310053510798"
+                "notionalPrincipal": 2344.86698499785,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 17.9310053510798
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "IP",
-                "payoff": "17.9310053510798",
+                "payoff": 17.9310053510798,
                 "currency": "USD",
-                "notionalPrincipal": "2344.86698499785",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2344.86698499785,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "PR",
-                "payoff": "384.138837251516",
+                "payoff": 384.138837251516,
                 "currency": "USD",
-                "notionalPrincipal": "1960.72814774633",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "15.9322469117662"
+                "notionalPrincipal": 1960.72814774633,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 15.9322469117662
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "IP",
-                "payoff": "15.9322469117662",
+                "payoff": 15.9322469117662,
                 "currency": "USD",
-                "notionalPrincipal": "1960.72814774633",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1960.72814774633,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "PR",
-                "payoff": "386.748876474485",
+                "payoff": 386.748876474485,
                 "currency": "USD",
-                "notionalPrincipal": "1573.97927127185",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "13.322207688797"
+                "notionalPrincipal": 1573.97927127185,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 13.322207688797
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "IP",
-                "payoff": "13.322207688797",
+                "payoff": 13.322207688797,
                 "currency": "USD",
-                "notionalPrincipal": "1573.97927127185",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1573.97927127185,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "PR",
-                "payoff": "389.721631420672",
+                "payoff": 389.721631420672,
                 "currency": "USD",
-                "notionalPrincipal": "1184.25763985117",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "10.3494527426094"
+                "notionalPrincipal": 1184.25763985117,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 10.3494527426094
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "IP",
-                "payoff": "10.3494527426094",
+                "payoff": 10.3494527426094,
                 "currency": "USD",
-                "notionalPrincipal": "1184.25763985117",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1184.25763985117,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "PR",
-                "payoff": "392.024621295252",
+                "payoff": 392.024621295252,
                 "currency": "USD",
-                "notionalPrincipal": "792.233018555922",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "8.0464628680299"
+                "notionalPrincipal": 792.233018555922,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 8.0464628680299
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "IP",
-                "payoff": "8.0464628680299",
+                "payoff": 8.0464628680299,
                 "currency": "USD",
-                "notionalPrincipal": "792.233018555922",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 792.233018555922,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-12-01T00:00",
                 "eventType": "PR",
-                "payoff": "394.861880753599",
+                "payoff": 394.861880753599,
                 "currency": "USD",
-                "notionalPrincipal": "397.371137802323",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "5.20920340968278"
+                "notionalPrincipal": 397.371137802323,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 5.20920340968278
             },
             {
                 "eventDate": "2013-12-01T00:00",
                 "eventType": "IP",
-                "payoff": "5.20920340968278",
+                "payoff": 5.20920340968278,
                 "currency": "USD",
-                "notionalPrincipal": "397.371137802323",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 397.371137802323,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-01-01T00:00",
                 "eventType": "IP",
-                "payoff": "2.69994636095825",
+                "payoff": 2.69994636095825,
                 "currency": "USD",
-                "notionalPrincipal": "397.371137802324",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 397.371137802324,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-01-01T00:00",
                 "eventType": "MD",
-                "payoff": "397.371137802324",
+                "payoff": 397.371137802324,
                 "currency": "USD",
-                "notionalPrincipal": "0.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 0.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             }
         ]
     },
@@ -2491,209 +2491,209 @@
             {
                 "eventDate": "2013-01-01T00:00",
                 "eventType": "IED",
-                "payoff": "-6000.0",
+                "payoff": -6000.0,
                 "currency": "USD",
-                "notionalPrincipal": "6000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 6000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "PR",
-                "payoff": "526.791668421684",
+                "payoff": 526.791668421684,
                 "currency": "USD",
-                "notionalPrincipal": "5473.20833157832",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "40.7671232876712"
+                "notionalPrincipal": 5473.20833157832,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 40.7671232876712
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "IP",
-                "payoff": "40.7671232876712",
+                "payoff": 40.7671232876712,
                 "currency": "USD",
-                "notionalPrincipal": "5473.20833157832",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 5473.20833157832,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "PR",
-                "payoff": "533.969787153916",
+                "payoff": 533.969787153916,
                 "currency": "USD",
-                "notionalPrincipal": "4939.2385444244",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "33.5890045554395"
+                "notionalPrincipal": 4939.2385444244,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 33.5890045554395
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "IP",
-                "payoff": "33.5890045554395",
+                "payoff": 33.5890045554395,
                 "currency": "USD",
-                "notionalPrincipal": "4939.2385444244",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4939.2385444244,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "PR",
-                "payoff": "533.999033928061",
+                "payoff": 533.999033928061,
                 "currency": "USD",
-                "notionalPrincipal": "4405.23951049634",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "33.5597577812945"
+                "notionalPrincipal": 4405.23951049634,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 33.5597577812945
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "IP",
-                "payoff": "33.5597577812945",
+                "payoff": 33.5597577812945,
                 "currency": "USD",
-                "notionalPrincipal": "4405.23951049634",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4405.23951049634,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "PR",
-                "payoff": "538.592833284174",
+                "payoff": 538.592833284174,
                 "currency": "USD",
-                "notionalPrincipal": "3866.64667721216",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "28.9659584251814"
+                "notionalPrincipal": 3866.64667721216,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 28.9659584251814
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "IP",
-                "payoff": "28.9659584251814",
+                "payoff": 28.9659584251814,
                 "currency": "USD",
-                "notionalPrincipal": "3866.64667721216",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3866.64667721216,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "PR",
-                "payoff": "541.286781409394",
+                "payoff": 541.286781409394,
                 "currency": "USD",
-                "notionalPrincipal": "3325.35989580277",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "26.2720102999621"
+                "notionalPrincipal": 3325.35989580277,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 26.2720102999621
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "IP",
-                "payoff": "26.2720102999621",
+                "payoff": 26.2720102999621,
                 "currency": "USD",
-                "notionalPrincipal": "3325.35989580277",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3325.35989580277,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "PR",
-                "payoff": "545.69341157257",
+                "payoff": 545.69341157257,
                 "currency": "USD",
-                "notionalPrincipal": "2779.6664842302",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "21.8653801367853"
+                "notionalPrincipal": 2779.6664842302,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 21.8653801367853
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "IP",
-                "payoff": "21.8653801367853",
+                "payoff": 21.8653801367853,
                 "currency": "USD",
-                "notionalPrincipal": "2779.6664842302",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2779.6664842302,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "PR",
-                "payoff": "548.672290665819",
+                "payoff": 548.672290665819,
                 "currency": "USD",
-                "notionalPrincipal": "2230.99419356438",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "18.8865010435367"
+                "notionalPrincipal": 2230.99419356438,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 18.8865010435367
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "IP",
-                "payoff": "18.8865010435367",
+                "payoff": 18.8865010435367,
                 "currency": "USD",
-                "notionalPrincipal": "2230.99419356438",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2230.99419356438,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "PR",
-                "payoff": "552.400255818836",
+                "payoff": 552.400255818836,
                 "currency": "USD",
-                "notionalPrincipal": "1678.59393774555",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "15.1585358905196"
+                "notionalPrincipal": 1678.59393774555,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 15.1585358905196
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "IP",
-                "payoff": "15.1585358905196",
+                "payoff": 15.1585358905196,
                 "currency": "USD",
-                "notionalPrincipal": "1678.59393774555",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1678.59393774555,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "PR",
-                "payoff": "556.521461707741",
+                "payoff": 556.521461707741,
                 "currency": "USD",
-                "notionalPrincipal": "1122.0724760378",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "11.0373300016145"
+                "notionalPrincipal": 1122.0724760378,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 11.0373300016145
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "IP",
-                "payoff": "11.0373300016145",
+                "payoff": 11.0373300016145,
                 "currency": "USD",
-                "notionalPrincipal": "1122.0724760378",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1122.0724760378,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "PR",
-                "payoff": "559.934847214633",
+                "payoff": 559.934847214633,
                 "currency": "USD",
-                "notionalPrincipal": "562.137628823171",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "7.62394449472261"
+                "notionalPrincipal": 562.137628823171,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 7.62394449472261
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "IP",
-                "payoff": "7.62394449472261",
+                "payoff": 7.62394449472261,
                 "currency": "USD",
-                "notionalPrincipal": "562.137628823171",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 562.137628823171,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-12-15T00:00",
                 "eventType": "IP",
-                "payoff": "5.4211628861851",
+                "payoff": 5.4211628861851,
                 "currency": "USD",
-                "notionalPrincipal": "562.137628823171",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 562.137628823171,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-12-15T00:00",
                 "eventType": "MD",
-                "payoff": "562.137628823171",
+                "payoff": 562.137628823171,
                 "currency": "USD",
-                "notionalPrincipal": "0.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 0.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             }
         ]
     },
@@ -2729,155 +2729,155 @@
             {
                 "eventDate": "2013-01-01T00:00",
                 "eventType": "IED",
-                "payoff": "-5000.0",
+                "payoff": -5000.0,
                 "currency": "USD",
-                "notionalPrincipal": "5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "PR",
-                "payoff": "666.027397260274",
+                "payoff": 666.027397260274,
                 "currency": "USD",
-                "notionalPrincipal": "4333.97260273973",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "33.972602739726"
+                "notionalPrincipal": 4333.97260273973,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 33.972602739726
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "IP",
-                "payoff": "33.972602739726",
+                "payoff": 33.972602739726,
                 "currency": "USD",
-                "notionalPrincipal": "4333.97260273973",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4333.97260273973,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "PR",
-                "payoff": "673.402469506474",
+                "payoff": 673.402469506474,
                 "currency": "USD",
-                "notionalPrincipal": "3660.57013323325",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "26.597530493526"
+                "notionalPrincipal": 3660.57013323325,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 26.597530493526
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "IP",
-                "payoff": "26.597530493526",
+                "payoff": 26.597530493526,
                 "currency": "USD",
-                "notionalPrincipal": "3660.57013323325",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3660.57013323325,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "PR",
-                "payoff": "675.128181012552",
+                "payoff": 675.128181012552,
                 "currency": "USD",
-                "notionalPrincipal": "2985.4419522207",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "24.8718189874479"
+                "notionalPrincipal": 2985.4419522207,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 24.8718189874479
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "IP",
-                "payoff": "24.8718189874479",
+                "payoff": 24.8718189874479,
                 "currency": "USD",
-                "notionalPrincipal": "2985.4419522207",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2985.4419522207,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "PR",
-                "payoff": "680.369696752522",
+                "payoff": 680.369696752522,
                 "currency": "USD",
-                "notionalPrincipal": "2305.07225546818",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "19.6303032474786"
+                "notionalPrincipal": 2305.07225546818,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 19.6303032474786
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "IP",
-                "payoff": "19.6303032474786",
+                "payoff": 19.6303032474786,
                 "currency": "USD",
-                "notionalPrincipal": "2305.07225546818",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2305.07225546818,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "PR",
-                "payoff": "684.338139195723",
+                "payoff": 684.338139195723,
                 "currency": "USD",
-                "notionalPrincipal": "1620.73411627246",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "15.6618608042769"
+                "notionalPrincipal": 1620.73411627246,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 15.6618608042769
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "IP",
-                "payoff": "15.6618608042769",
+                "payoff": 15.6618608042769,
                 "currency": "USD",
-                "notionalPrincipal": "1620.73411627246",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1620.73411627246,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "PR",
-                "payoff": "689.343118139578",
+                "payoff": 689.343118139578,
                 "currency": "USD",
-                "notionalPrincipal": "931.390998132877",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "10.6568818604216"
+                "notionalPrincipal": 931.390998132877,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 10.6568818604216
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "IP",
-                "payoff": "10.6568818604216",
+                "payoff": 10.6568818604216,
                 "currency": "USD",
-                "notionalPrincipal": "931.390998132877",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 931.390998132877,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "PR",
-                "payoff": "693.671644725015",
+                "payoff": 693.671644725015,
                 "currency": "USD",
-                "notionalPrincipal": "237.719353407862",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "6.32835527498503"
+                "notionalPrincipal": 237.719353407862,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 6.32835527498503
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "IP",
-                "payoff": "6.32835527498503",
+                "payoff": 6.32835527498503,
                 "currency": "USD",
-                "notionalPrincipal": "237.719353407862",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 237.719353407862,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "IP",
-                "payoff": "1.61518903137397",
+                "payoff": 1.61518903137397,
                 "currency": "USD",
-                "notionalPrincipal": "237.719353407862",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 237.719353407862,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "MD",
-                "payoff": "237.719353407862",
+                "payoff": 237.719353407862,
                 "currency": "USD",
-                "notionalPrincipal": "0.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 0.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             }
         ]
     },
@@ -2912,203 +2912,203 @@
         "results": [ {
             "eventDate" : "2013-01-01T00:00",
             "eventType" : "IED",
-            "payoff" : "-5000.0",
+            "payoff": -5000.0,
             "currency" : "USD",
-            "notionalPrincipal" : "5000.0",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 5000.0,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2013-02-01T00:00",
             "eventType" : "PR",
-            "payoff" : "400.8939913786",
+            "payoff": 400.8939913786,
             "currency" : "USD",
-            "notionalPrincipal" : "4599.1060086213",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "33.9726027397"
+            "notionalPrincipal": 4599.1060086213,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 33.9726027397
         }, {
             "eventDate" : "2013-02-01T00:00",
             "eventType" : "IP",
-            "payoff" : "33.9726027397",
+            "payoff": 33.9726027397,
             "currency" : "USD",
-            "notionalPrincipal" : "4599.1060086213",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 4599.1060086213,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2013-03-01T00:00",
             "eventType" : "PR",
-            "payoff" : "406.6419435448",
+            "payoff": 406.6419435448,
             "currency" : "USD",
-            "notionalPrincipal" : "4192.4640650764",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "28.2246505734"
+            "notionalPrincipal": 4192.4640650764,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 28.2246505734
         }, {
             "eventDate" : "2013-03-01T00:00",
             "eventType" : "IP",
-            "payoff" : "28.2246505734",
+            "payoff": 28.2246505734,
             "currency" : "USD",
-            "notionalPrincipal" : "4192.4640650764",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 4192.4640650764,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2013-04-01T00:00",
             "eventType" : "PR",
-            "payoff" : "406.3808108816",
+            "payoff": 406.3808108816,
             "currency" : "USD",
-            "notionalPrincipal" : "3786.0832541948",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "28.4857832366"
+            "notionalPrincipal": 3786.0832541948,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 28.4857832366
         }, {
             "eventDate" : "2013-04-01T00:00",
             "eventType" : "IP",
-            "payoff" : "28.4857832366",
+            "payoff": 28.4857832366,
             "currency" : "USD",
-            "notionalPrincipal" : "3786.0832541948",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 3786.0832541948,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2013-05-01T00:00",
             "eventType" : "PR",
-            "payoff" : "409.9718001181",
+            "payoff": 409.9718001181,
             "currency" : "USD",
-            "notionalPrincipal" : "3376.1114540766",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "24.8947940001"
+            "notionalPrincipal": 3376.1114540766,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 24.8947940001
         }, {
             "eventDate" : "2013-05-01T00:00",
             "eventType" : "IP",
-            "payoff" : "24.8947940001",
+            "payoff": 24.8947940001,
             "currency" : "USD",
-            "notionalPrincipal" : "3376.1114540766",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 3376.1114540766,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2013-06-01T00:00",
             "eventType" : "PR",
-            "payoff" : "411.9275354714",
+            "payoff": 411.9275354714,
             "currency" : "USD",
-            "notionalPrincipal" : "2964.1839186051",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "22.9390586468"
+            "notionalPrincipal": 2964.1839186051,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 22.9390586468
         }, {
             "eventDate" : "2013-06-01T00:00",
             "eventType" : "IP",
-            "payoff" : "22.9390586468",
+            "payoff": 22.9390586468,
             "currency" : "USD",
-            "notionalPrincipal" : "2964.1839186051",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 2964.1839186051,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2013-07-01T00:00",
             "eventType" : "PR",
-            "payoff" : "415.376069722",
+            "payoff": 415.376069722,
             "currency" : "USD",
-            "notionalPrincipal" : "2548.8078488831",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "19.4905243963"
+            "notionalPrincipal": 2548.8078488831,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 19.4905243963
         }, {
             "eventDate" : "2013-07-01T00:00",
             "eventType" : "IP",
-            "payoff" : "19.4905243963",
+            "payoff": 19.4905243963,
             "currency" : "USD",
-            "notionalPrincipal" : "2548.8078488831",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 2548.8078488831,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2013-08-01T00:00",
             "eventType" : "PR",
-            "payoff" : "417.5486668163",
+            "payoff": 417.5486668163,
             "currency" : "USD",
-            "notionalPrincipal" : "2131.2591820668",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "17.317927302"
+            "notionalPrincipal": 2131.2591820668,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 17.317927302
         }, {
             "eventDate" : "2013-08-01T00:00",
             "eventType" : "IP",
-            "payoff" : "17.317927302",
+            "payoff": 17.317927302,
             "currency" : "USD",
-            "notionalPrincipal" : "2131.2591820668",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 2131.2591820668,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2013-09-01T00:00",
             "eventType" : "PR",
-            "payoff" : "420.3857098127",
+            "payoff": 420.3857098127,
             "currency" : "USD",
-            "notionalPrincipal" : "1710.873472254",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "14.4808843055"
+            "notionalPrincipal": 1710.873472254,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 14.4808843055
         }, {
             "eventDate" : "2013-09-01T00:00",
             "eventType" : "IP",
-            "payoff" : "14.4808843055",
+            "payoff": 14.4808843055,
             "currency" : "USD",
-            "notionalPrincipal" : "1710.873472254",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 1710.873472254,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2013-10-01T00:00",
             "eventType" : "PR",
-            "payoff" : "423.6170151227",
+            "payoff": 423.6170151227,
             "currency" : "USD",
-            "notionalPrincipal" : "1287.2564571313",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "11.2495789956"
+            "notionalPrincipal": 1287.2564571313,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 11.2495789956
         }, {
             "eventDate" : "2013-10-01T00:00",
             "eventType" : "IP",
-            "payoff" : "11.2495789956",
+            "payoff": 11.2495789956,
             "currency" : "USD",
-            "notionalPrincipal" : "1287.2564571313",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 1287.2564571313,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2013-11-01T00:00",
             "eventType" : "PR",
-            "payoff" : "426.1203036698",
+            "payoff": 426.1203036698,
             "currency" : "USD",
-            "notionalPrincipal" : "861.1361534614",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "8.7462904484"
+            "notionalPrincipal": 861.1361534614,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 8.7462904484
         }, {
             "eventDate" : "2013-11-01T00:00",
             "eventType" : "IP",
-            "payoff" : "8.7462904484",
+            "payoff": 8.7462904484,
             "currency" : "USD",
-            "notionalPrincipal" : "861.1361534614",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 861.1361534614,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2013-12-01T00:00",
             "eventType" : "PR",
-            "payoff" : "429.2043289996",
+            "payoff": 429.2043289996,
             "currency" : "USD",
-            "notionalPrincipal" : "431.9318244617",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "5.6622651186"
+            "notionalPrincipal": 431.9318244617,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 5.6622651186
         }, {
             "eventDate" : "2013-12-01T00:00",
             "eventType" : "IP",
-            "payoff" : "5.6622651186",
+            "payoff": 5.6622651186,
             "currency" : "USD",
-            "notionalPrincipal" : "431.9318244617",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 431.9318244617,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2014-01-01T00:00",
             "eventType" : "IP",
-            "payoff" : "2.9347696566",
+            "payoff": 2.9347696566,
             "currency" : "USD",
-            "notionalPrincipal" : "431.9318244617",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 431.9318244617,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 0.0
         }, {
             "eventDate" : "2014-01-01T00:00",
             "eventType" : "MD",
-            "payoff" : "431.9318244617",
+            "payoff": 431.9318244617,
             "currency" : "USD",
-            "notionalPrincipal" : "0.0",
-            "nominalInterestRate" : "0.08",
-            "accruedInterest" : "0.0"
+            "notionalPrincipal": 0.0,
+            "nominalInterestRate": 0.08,
+            "accruedInterest": 0.0
         } ]
     },
     "ann07": {
@@ -3142,236 +3142,236 @@
             {
                 "eventDate": "2013-01-01T00:00",
                 "eventType": "IED",
-                "payoff": "-5000.0",
+                "payoff": -5000.0,
                 "currency": "USD",
-                "notionalPrincipal": "5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-01-31T00:00",
                 "eventType": "PRF",
-                "payoff": "0",
+                "payoff": 0,
                 "currency": "USD",
-                "notionalPrincipal": "5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "32.87671232876712"
+                "notionalPrincipal": 5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 32.87671232876712
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "PR",
-                "payoff": "400.89399137862",
+                "payoff": 400.89399137862,
                 "currency": "USD",
-                "notionalPrincipal": "4599.10600862138",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "33.972602739726"
+                "notionalPrincipal": 4599.10600862138,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 33.972602739726
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "IP",
-                "payoff": "33.972602739726",
+                "payoff": 33.972602739726,
                 "currency": "USD",
-                "notionalPrincipal": "4599.10600862138",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4599.10600862138,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "PR",
-                "payoff": "406.641943544889",
+                "payoff": 406.641943544889,
                 "currency": "USD",
-                "notionalPrincipal": "4192.46406507649",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "28.2246505734572"
+                "notionalPrincipal": 4192.46406507649,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 28.2246505734572
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "IP",
-                "payoff": "28.2246505734572",
+                "payoff": 28.2246505734572,
                 "currency": "USD",
-                "notionalPrincipal": "4192.46406507649",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4192.46406507649,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "PR",
-                "payoff": "406.380810881662",
+                "payoff": 406.380810881662,
                 "currency": "USD",
-                "notionalPrincipal": "3786.08325419483",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "28.4857832366841"
+                "notionalPrincipal": 3786.08325419483,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 28.4857832366841
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "IP",
-                "payoff": "28.4857832366841",
+                "payoff": 28.4857832366841,
                 "currency": "USD",
-                "notionalPrincipal": "3786.08325419483",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3786.08325419483,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "PR",
-                "payoff": "409.971800118161",
+                "payoff": 409.971800118161,
                 "currency": "USD",
-                "notionalPrincipal": "3376.11145407667",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "24.8947940001852"
+                "notionalPrincipal": 3376.11145407667,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 24.8947940001852
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "IP",
-                "payoff": "24.8947940001852",
+                "payoff": 24.8947940001852,
                 "currency": "USD",
-                "notionalPrincipal": "3376.11145407667",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3376.11145407667,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "PR",
-                "payoff": "411.927535471469",
+                "payoff": 411.927535471469,
                 "currency": "USD",
-                "notionalPrincipal": "2964.1839186051",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "22.9390586468771"
+                "notionalPrincipal": 2964.1839186051,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 22.9390586468771
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "IP",
-                "payoff": "22.9390586468771",
+                "payoff": 22.9390586468771,
                 "currency": "USD",
-                "notionalPrincipal": "2964.1839186051",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2964.1839186051,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "PR",
-                "payoff": "415.376069722038",
+                "payoff": 415.376069722038,
                 "currency": "USD",
-                "notionalPrincipal": "2548.80784888316",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "19.4905243963082"
+                "notionalPrincipal": 2548.80784888316,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 19.4905243963082
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "IP",
-                "payoff": "19.4905243963082",
+                "payoff": 19.4905243963082,
                 "currency": "USD",
-                "notionalPrincipal": "2548.80784888316",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2548.80784888316,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "PR",
-                "payoff": "417.548666816345",
+                "payoff": 417.548666816345,
                 "currency": "USD",
-                "notionalPrincipal": "2131.25918206682",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "17.3179273020007"
+                "notionalPrincipal": 2131.25918206682,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 17.3179273020007
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "IP",
-                "payoff": "17.3179273020007",
+                "payoff": 17.3179273020007,
                 "currency": "USD",
-                "notionalPrincipal": "2131.25918206682",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2131.25918206682,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "PR",
-                "payoff": "420.385709812796",
+                "payoff": 420.385709812796,
                 "currency": "USD",
-                "notionalPrincipal": "1710.87347225402",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "14.4808843055499"
+                "notionalPrincipal": 1710.87347225402,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 14.4808843055499
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "IP",
-                "payoff": "14.4808843055499",
+                "payoff": 14.4808843055499,
                 "currency": "USD",
-                "notionalPrincipal": "1710.87347225402",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1710.87347225402,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "PR",
-                "payoff": "423.617015122703",
+                "payoff": 423.617015122703,
                 "currency": "USD",
-                "notionalPrincipal": "1287.25645713132",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "11.2495789956429"
+                "notionalPrincipal": 1287.25645713132,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 11.2495789956429
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "IP",
-                "payoff": "11.2495789956429",
+                "payoff": 11.2495789956429,
                 "currency": "USD",
-                "notionalPrincipal": "1287.25645713132",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1287.25645713132,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "PR",
-                "payoff": "426.120303669892",
+                "payoff": 426.120303669892,
                 "currency": "USD",
-                "notionalPrincipal": "861.136153461425",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "8.74629044845388"
+                "notionalPrincipal": 861.136153461425,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 8.74629044845388
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "IP",
-                "payoff": "8.74629044845388",
+                "payoff": 8.74629044845388,
                 "currency": "USD",
-                "notionalPrincipal": "861.136153461425",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 861.136153461425,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-12-01T00:00",
                 "eventType": "PR",
-                "payoff": "429.204328999696",
+                "payoff": 429.204328999696,
                 "currency": "USD",
-                "notionalPrincipal": "431.931824461729",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "5.66226511865046"
+                "notionalPrincipal": 431.931824461729,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 5.66226511865046
             },
             {
                 "eventDate": "2013-12-01T00:00",
                 "eventType": "IP",
-                "payoff": "5.66226511865046",
+                "payoff": 5.66226511865046,
                 "currency": "USD",
-                "notionalPrincipal": "431.931824461729",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 431.931824461729,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-01-01T00:00",
                 "eventType": "IP",
-                "payoff": "2.93476965661668",
+                "payoff": 2.93476965661668,
                 "currency": "USD",
-                "notionalPrincipal": "431.931824461729",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 431.931824461729,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-01-01T00:00",
                 "eventType": "MD",
-                "payoff": "431.931824461729",
+                "payoff": 431.931824461729,
                 "currency": "USD",
-                "notionalPrincipal": "0.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0"
+                "notionalPrincipal": 0.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0
             }
         ]
     },
@@ -3406,1334 +3406,1334 @@
             {
                 "eventDate": "2013-01-01T00:00",
                 "eventType": "IED",
-                "payoff": "-100000.0",
+                "payoff": -100000.0,
                 "currency": "USD",
-                "notionalPrincipal": "100000.0",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 100000.0,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-01-31T00:00",
                 "eventType": "PRF",
-                "payoff": "0",
+                "payoff": 0,
                 "currency": "USD",
-                "notionalPrincipal": "100000.0",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "563.8888888888889"
+                "notionalPrincipal": 100000.0,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 563.8888888888889
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "PR",
-                "payoff": "577.751458852908",
+                "payoff": 577.751458852908,
                 "currency": "USD",
-                "notionalPrincipal": "99422.2485411471",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "583.333333333333"
+                "notionalPrincipal": 99422.2485411471,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 583.333333333333
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "IP",
-                "payoff": "583.333333333333",
+                "payoff": 583.333333333333,
                 "currency": "USD",
-                "notionalPrincipal": "99422.2485411471",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 99422.2485411471,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "PR",
-                "payoff": "581.121675696217",
+                "payoff": 581.121675696217,
                 "currency": "USD",
-                "notionalPrincipal": "98841.1268654508",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "579.963116490025"
+                "notionalPrincipal": 98841.1268654508,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 579.963116490025
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "IP",
-                "payoff": "579.963116490025",
+                "payoff": 579.963116490025,
                 "currency": "USD",
-                "notionalPrincipal": "98841.1268654508",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 98841.1268654508,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "PR",
-                "payoff": "584.511552137778",
+                "payoff": 584.511552137778,
                 "currency": "USD",
-                "notionalPrincipal": "98256.6153133131",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "576.573240048463"
+                "notionalPrincipal": 98256.6153133131,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 576.573240048463
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "IP",
-                "payoff": "576.573240048463",
+                "payoff": 576.573240048463,
                 "currency": "USD",
-                "notionalPrincipal": "98256.6153133131",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 98256.6153133131,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "PR",
-                "payoff": "587.921202858582",
+                "payoff": 587.921202858582,
                 "currency": "USD",
-                "notionalPrincipal": "97668.6941104545",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "573.16358932766"
+                "notionalPrincipal": 97668.6941104545,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 573.16358932766
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "IP",
-                "payoff": "573.16358932766",
+                "payoff": 573.16358932766,
                 "currency": "USD",
-                "notionalPrincipal": "97668.6941104545",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 97668.6941104545,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "PR",
-                "payoff": "591.35074320859",
+                "payoff": 591.35074320859,
                 "currency": "USD",
-                "notionalPrincipal": "97077.3433672459",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "569.734048977652"
+                "notionalPrincipal": 97077.3433672459,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 569.734048977652
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "IP",
-                "payoff": "569.734048977652",
+                "payoff": 569.734048977652,
                 "currency": "USD",
-                "notionalPrincipal": "97077.3433672459",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 97077.3433672459,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "PR",
-                "payoff": "594.80028921064",
+                "payoff": 594.80028921064,
                 "currency": "USD",
-                "notionalPrincipal": "96482.5430780352",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "566.284502975601"
+                "notionalPrincipal": 96482.5430780352,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 566.284502975601
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "IP",
-                "payoff": "566.284502975601",
+                "payoff": 566.284502975601,
                 "currency": "USD",
-                "notionalPrincipal": "96482.5430780352",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 96482.5430780352,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "PR",
-                "payoff": "598.269957564369",
+                "payoff": 598.269957564369,
                 "currency": "USD",
-                "notionalPrincipal": "95884.2731204709",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "562.814834621873"
+                "notionalPrincipal": 95884.2731204709,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 562.814834621873
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "IP",
-                "payoff": "562.814834621873",
+                "payoff": 562.814834621873,
                 "currency": "USD",
-                "notionalPrincipal": "95884.2731204709",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 95884.2731204709,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "PR",
-                "payoff": "601.759865650161",
+                "payoff": 601.759865650161,
                 "currency": "USD",
-                "notionalPrincipal": "95282.5132548207",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "559.32492653608"
+                "notionalPrincipal": 95282.5132548207,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 559.32492653608
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "IP",
-                "payoff": "559.32492653608",
+                "payoff": 559.32492653608,
                 "currency": "USD",
-                "notionalPrincipal": "95282.5132548207",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 95282.5132548207,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "PR",
-                "payoff": "605.270131533121",
+                "payoff": 605.270131533121,
                 "currency": "USD",
-                "notionalPrincipal": "94677.2431232876",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "555.814660653121"
+                "notionalPrincipal": 94677.2431232876,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 555.814660653121
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "IP",
-                "payoff": "555.814660653121",
+                "payoff": 555.814660653121,
                 "currency": "USD",
-                "notionalPrincipal": "94677.2431232876",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 94677.2431232876,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "PR",
-                "payoff": "608.800873967064",
+                "payoff": 608.800873967064,
                 "currency": "USD",
-                "notionalPrincipal": "94068.4422493205",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "552.283918219178"
+                "notionalPrincipal": 94068.4422493205,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 552.283918219178
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "IP",
-                "payoff": "552.283918219178",
+                "payoff": 552.283918219178,
                 "currency": "USD",
-                "notionalPrincipal": "94068.4422493205",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 94068.4422493205,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-12-01T00:00",
                 "eventType": "PR",
-                "payoff": "612.352212398538",
+                "payoff": 612.352212398538,
                 "currency": "USD",
-                "notionalPrincipal": "93456.0900369220",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "548.732579787703"
+                "notionalPrincipal": 93456.0900369220,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 548.732579787703
             },
             {
                 "eventDate": "2013-12-01T00:00",
                 "eventType": "IP",
-                "payoff": "548.732579787703",
+                "payoff": 548.732579787703,
                 "currency": "USD",
-                "notionalPrincipal": "93456.0900369220",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 93456.0900369220,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-01-01T00:00",
                 "eventType": "PR",
-                "payoff": "615.924266970863",
+                "payoff": 615.924266970863,
                 "currency": "USD",
-                "notionalPrincipal": "92840.1657699511",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "545.160525215379"
+                "notionalPrincipal": 92840.1657699511,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 545.160525215379
             },
             {
                 "eventDate": "2014-01-01T00:00",
                 "eventType": "IP",
-                "payoff": "545.160525215379",
+                "payoff": 545.160525215379,
                 "currency": "USD",
-                "notionalPrincipal": "92840.1657699511",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 92840.1657699511,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-02-01T00:00",
                 "eventType": "PR",
-                "payoff": "619.517158528193",
+                "payoff": 619.517158528193,
                 "currency": "USD",
-                "notionalPrincipal": "92220.6486114229",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "541.567633658049"
+                "notionalPrincipal": 92220.6486114229,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 541.567633658049
             },
             {
                 "eventDate": "2014-02-01T00:00",
                 "eventType": "IP",
-                "payoff": "541.567633658049",
+                "payoff": 541.567633658049,
                 "currency": "USD",
-                "notionalPrincipal": "92220.6486114229",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 92220.6486114229,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-03-01T00:00",
                 "eventType": "PR",
-                "payoff": "623.131008619608",
+                "payoff": 623.131008619608,
                 "currency": "USD",
-                "notionalPrincipal": "91597.5176028033",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "537.953783566634"
+                "notionalPrincipal": 91597.5176028033,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 537.953783566634
             },
             {
                 "eventDate": "2014-03-01T00:00",
                 "eventType": "IP",
-                "payoff": "537.953783566634",
+                "payoff": 537.953783566634,
                 "currency": "USD",
-                "notionalPrincipal": "91597.5176028033",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 91597.5176028033,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-04-01T00:00",
                 "eventType": "PR",
-                "payoff": "626.765939503222",
+                "payoff": 626.765939503222,
                 "currency": "USD",
-                "notionalPrincipal": "90970.7516633001",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "534.31885268302"
+                "notionalPrincipal": 90970.7516633001,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 534.31885268302
             },
             {
                 "eventDate": "2014-04-01T00:00",
                 "eventType": "IP",
-                "payoff": "534.31885268301",
+                "payoff": 534.31885268301,
                 "currency": "USD",
-                "notionalPrincipal": "90970.7516633001",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 90970.7516633001,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-05-01T00:00",
                 "eventType": "PR",
-                "payoff": "630.422074150324",
+                "payoff": 630.422074150324,
                 "currency": "USD",
-                "notionalPrincipal": "90340.3295891498",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "530.662718035918"
+                "notionalPrincipal": 90340.3295891498,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 530.662718035918
             },
             {
                 "eventDate": "2014-05-01T00:00",
                 "eventType": "IP",
-                "payoff": "530.662718035918",
+                "payoff": 530.662718035918,
                 "currency": "USD",
-                "notionalPrincipal": "90340.3295891498",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 90340.3295891498,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-06-01T00:00",
                 "eventType": "PR",
-                "payoff": "634.099536249534",
+                "payoff": 634.099536249534,
                 "currency": "USD",
-                "notionalPrincipal": "89706.2300529003",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "526.985255936707"
+                "notionalPrincipal": 89706.2300529003,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 526.985255936707
             },
             {
                 "eventDate": "2014-06-01T00:00",
                 "eventType": "IP",
-                "payoff": "526.985255936707",
+                "payoff": 526.985255936707,
                 "currency": "USD",
-                "notionalPrincipal": "89706.2300529003",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 89706.2300529003,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-07-01T00:00",
                 "eventType": "PR",
-                "payoff": "637.79845021099",
+                "payoff": 637.79845021099,
                 "currency": "USD",
-                "notionalPrincipal": "89068.4316026893",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "523.286341975252"
+                "notionalPrincipal": 89068.4316026893,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 523.286341975252
             },
             {
                 "eventDate": "2014-07-01T00:00",
                 "eventType": "IP",
-                "payoff": "523.286341975252",
+                "payoff": 523.286341975252,
                 "currency": "USD",
-                "notionalPrincipal": "89068.4316026893",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 89068.4316026893,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-08-01T00:00",
                 "eventType": "PR",
-                "payoff": "641.518941170554",
+                "payoff": 641.518941170554,
                 "currency": "USD",
-                "notionalPrincipal": "88426.9126615187",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "519.565851015688"
+                "notionalPrincipal": 88426.9126615187,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 519.565851015688
             },
             {
                 "eventDate": "2014-08-01T00:00",
                 "eventType": "IP",
-                "payoff": "519.565851015688",
+                "payoff": 519.565851015688,
                 "currency": "USD",
-                "notionalPrincipal": "88426.9126615187",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 88426.9126615187,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-09-01T00:00",
                 "eventType": "PR",
-                "payoff": "645.261134994049",
+                "payoff": 645.261134994049,
                 "currency": "USD",
-                "notionalPrincipal": "87781.6515265247",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "515.823657192193"
+                "notionalPrincipal": 87781.6515265247,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 515.823657192193
             },
             {
                 "eventDate": "2014-09-01T00:00",
                 "eventType": "IP",
-                "payoff": "515.823657192193",
+                "payoff": 515.823657192193,
                 "currency": "USD",
-                "notionalPrincipal": "87781.6515265247",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 87781.6515265247,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-10-01T00:00",
                 "eventType": "PR",
-                "payoff": "649.025158281514",
+                "payoff": 649.025158281514,
                 "currency": "USD",
-                "notionalPrincipal": "87132.6263682432",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "512.059633904728"
+                "notionalPrincipal": 87132.6263682432,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 512.059633904728
             },
             {
                 "eventDate": "2014-10-01T00:00",
                 "eventType": "IP",
-                "payoff": "512.059633904728",
+                "payoff": 512.059633904728,
                 "currency": "USD",
-                "notionalPrincipal": "87132.6263682432",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 87132.6263682432,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-11-01T00:00",
                 "eventType": "PR",
-                "payoff": "652.81113837149",
+                "payoff": 652.81113837149,
                 "currency": "USD",
-                "notionalPrincipal": "86479.8152298717",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "508.273653814752"
+                "notionalPrincipal": 86479.8152298717,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 508.273653814752
             },
             {
                 "eventDate": "2014-11-01T00:00",
                 "eventType": "IP",
-                "payoff": "508.273653814752",
+                "payoff": 508.273653814752,
                 "currency": "USD",
-                "notionalPrincipal": "86479.8152298717",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 86479.8152298717,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-12-01T00:00",
                 "eventType": "PR",
-                "payoff": "656.619203345323",
+                "payoff": 656.619203345323,
                 "currency": "USD",
-                "notionalPrincipal": "85823.1960265264",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "504.465588840919"
+                "notionalPrincipal": 85823.1960265264,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 504.465588840919
             },
             {
                 "eventDate": "2014-12-01T00:00",
                 "eventType": "IP",
-                "payoff": "504.465588840919",
+                "payoff": 504.465588840919,
                 "currency": "USD",
-                "notionalPrincipal": "85823.1960265264",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 85823.1960265264,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2015-01-01T00:00",
                 "eventType": "PR",
-                "payoff": "660.449482031504",
+                "payoff": 660.449482031504,
                 "currency": "USD",
-                "notionalPrincipal": "85162.7465444949",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "500.635310154737"
+                "notionalPrincipal": 85162.7465444949,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 500.635310154737
             },
             {
                 "eventDate": "2015-01-01T00:00",
                 "eventType": "IP",
-                "payoff": "500.635310154737",
+                "payoff": 500.635310154737,
                 "currency": "USD",
-                "notionalPrincipal": "85162.7465444949",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 85162.7465444949,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2015-02-01T00:00",
                 "eventType": "PR",
-                "payoff": "664.302104010021",
+                "payoff": 664.302104010021,
                 "currency": "USD",
-                "notionalPrincipal": "84498.4444404848",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "496.78268817622"
+                "notionalPrincipal": 84498.4444404848,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 496.78268817622
             },
             {
                 "eventDate": "2015-02-01T00:00",
                 "eventType": "IP",
-                "payoff": "496.78268817622",
+                "payoff": 496.78268817622,
                 "currency": "USD",
-                "notionalPrincipal": "84498.4444404848",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 84498.4444404848,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2015-03-01T00:00",
                 "eventType": "PR",
-                "payoff": "668.177199616747",
+                "payoff": 668.177199616747,
                 "currency": "USD",
-                "notionalPrincipal": "83830.2672408681",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "492.907592569495"
+                "notionalPrincipal": 83830.2672408681,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 492.907592569495
             },
             {
                 "eventDate": "2015-03-01T00:00",
                 "eventType": "IP",
-                "payoff": "492.907592569495",
+                "payoff": 492.907592569495,
                 "currency": "USD",
-                "notionalPrincipal": "83830.2672408681",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 83830.2672408681,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2015-04-01T00:00",
                 "eventType": "PR",
-                "payoff": "672.074899947844",
+                "payoff": 672.074899947844,
                 "currency": "USD",
-                "notionalPrincipal": "83158.1923409202",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "489.009892238397"
+                "notionalPrincipal": 83158.1923409202,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 489.009892238397
             },
             {
                 "eventDate": "2015-04-01T00:00",
                 "eventType": "IP",
-                "payoff": "489.009892238397",
+                "payoff": 489.009892238397,
                 "currency": "USD",
-                "notionalPrincipal": "83158.1923409202",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 83158.1923409202,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2015-05-01T00:00",
                 "eventType": "PR",
-                "payoff": "675.995336864207",
+                "payoff": 675.995336864207,
                 "currency": "USD",
-                "notionalPrincipal": "82482.197004056",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "485.089455322035"
+                "notionalPrincipal": 82482.197004056,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 485.089455322035
             },
             {
                 "eventDate": "2015-05-01T00:00",
                 "eventType": "IP",
-                "payoff": "485.089455322035",
+                "payoff": 485.089455322035,
                 "currency": "USD",
-                "notionalPrincipal": "82482.197004056",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 82482.197004056,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2015-06-01T00:00",
                 "eventType": "PR",
-                "payoff": "679.938642995915",
+                "payoff": 679.938642995915,
                 "currency": "USD",
-                "notionalPrincipal": "81802.2583610601",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "481.146149190327"
+                "notionalPrincipal": 81802.2583610601,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 481.146149190327
             },
             {
                 "eventDate": "2015-06-01T00:00",
                 "eventType": "IP",
-                "payoff": "481.146149190327",
+                "payoff": 481.146149190327,
                 "currency": "USD",
-                "notionalPrincipal": "81802.2583610601",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 81802.2583610601,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2015-07-01T00:00",
                 "eventType": "PR",
-                "payoff": "683.904951746724",
+                "payoff": 683.904951746724,
                 "currency": "USD",
-                "notionalPrincipal": "81118.3534093134",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "477.179840439518"
+                "notionalPrincipal": 81118.3534093134,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 477.179840439518
             },
             {
                 "eventDate": "2015-07-01T00:00",
                 "eventType": "IP",
-                "payoff": "477.179840439518",
+                "payoff": 477.179840439518,
                 "currency": "USD",
-                "notionalPrincipal": "81118.3534093134",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 81118.3534093134,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2015-08-01T00:00",
                 "eventType": "PR",
-                "payoff": "687.89439729858",
+                "payoff": 687.89439729858,
                 "currency": "USD",
-                "notionalPrincipal": "80430.4590120148",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "473.190394887662"
+                "notionalPrincipal": 80430.4590120148,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 473.190394887662
             },
             {
                 "eventDate": "2015-08-01T00:00",
                 "eventType": "IP",
-                "payoff": "473.190394887662",
+                "payoff": 473.190394887662,
                 "currency": "USD",
-                "notionalPrincipal": "80430.4590120148",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 80430.4590120148,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2015-09-01T00:00",
                 "eventType": "PR",
-                "payoff": "691.907114616155",
+                "payoff": 691.907114616155,
                 "currency": "USD",
-                "notionalPrincipal": "79738.5518973987",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "469.177677570087"
+                "notionalPrincipal": 79738.5518973987,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 469.177677570087
             },
             {
                 "eventDate": "2015-09-01T00:00",
                 "eventType": "IP",
-                "payoff": "469.177677570087",
+                "payoff": 469.177677570087,
                 "currency": "USD",
-                "notionalPrincipal": "79738.5518973987",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 79738.5518973987,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2015-10-01T00:00",
                 "eventType": "PR",
-                "payoff": "695.943239451416",
+                "payoff": 695.943239451416,
                 "currency": "USD",
-                "notionalPrincipal": "79042.6086579473",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "465.141552734826"
+                "notionalPrincipal": 79042.6086579473,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 465.141552734826
             },
             {
                 "eventDate": "2015-10-01T00:00",
                 "eventType": "IP",
-                "payoff": "465.141552734826",
+                "payoff": 465.141552734826,
                 "currency": "USD",
-                "notionalPrincipal": "79042.6086579473",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 79042.6086579473,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2015-11-01T00:00",
                 "eventType": "PR",
-                "payoff": "700.002908348216",
+                "payoff": 700.002908348216,
                 "currency": "USD",
-                "notionalPrincipal": "78342.605749599",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "461.081883838026"
+                "notionalPrincipal": 78342.605749599,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 461.081883838026
             },
             {
                 "eventDate": "2015-11-01T00:00",
                 "eventType": "IP",
-                "payoff": "461.081883838026",
+                "payoff": 461.081883838026,
                 "currency": "USD",
-                "notionalPrincipal": "78342.605749599",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 78342.605749599,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2015-12-01T00:00",
                 "eventType": "PR",
-                "payoff": "704.086258646914",
+                "payoff": 704.086258646914,
                 "currency": "USD",
-                "notionalPrincipal": "77638.5194909521",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "456.998533539328"
+                "notionalPrincipal": 77638.5194909521,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 456.998533539328
             },
             {
                 "eventDate": "2015-12-01T00:00",
                 "eventType": "IP",
-                "payoff": "456.998533539328",
+                "payoff": 456.998533539328,
                 "currency": "USD",
-                "notionalPrincipal": "77638.5194909521",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 77638.5194909521,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2016-01-01T00:00",
                 "eventType": "PR",
-                "payoff": "708.193428489021",
+                "payoff": 708.193428489021,
                 "currency": "USD",
-                "notionalPrincipal": "76930.3260624631",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "452.891363697221"
+                "notionalPrincipal": 76930.3260624631,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 452.891363697221
             },
             {
                 "eventDate": "2016-01-01T00:00",
                 "eventType": "IP",
-                "payoff": "452.891363697221",
+                "payoff": 452.891363697221,
                 "currency": "USD",
-                "notionalPrincipal": "76930.3260624631",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 76930.3260624631,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2016-02-01T00:00",
                 "eventType": "PR",
-                "payoff": "712.324556821873",
+                "payoff": 712.324556821873,
                 "currency": "USD",
-                "notionalPrincipal": "76218.0015056412",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "448.760235364368"
+                "notionalPrincipal": 76218.0015056412,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 448.760235364368
             },
             {
                 "eventDate": "2016-02-01T00:00",
                 "eventType": "IP",
-                "payoff": "448.760235364368",
+                "payoff": 448.760235364368,
                 "currency": "USD",
-                "notionalPrincipal": "76218.0015056412",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 76218.0015056412,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2016-03-01T00:00",
                 "eventType": "PR",
-                "payoff": "716.479783403334",
+                "payoff": 716.479783403334,
                 "currency": "USD",
-                "notionalPrincipal": "75501.5217222379",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "444.605008782908"
+                "notionalPrincipal": 75501.5217222379,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 444.605008782908
             },
             {
                 "eventDate": "2016-03-01T00:00",
                 "eventType": "IP",
-                "payoff": "444.605008782908",
+                "payoff": 444.605008782908,
                 "currency": "USD",
-                "notionalPrincipal": "75501.5217222379",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 75501.5217222379,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2016-04-01T00:00",
                 "eventType": "PR",
-                "payoff": "720.65924880652",
+                "payoff": 720.65924880652,
                 "currency": "USD",
-                "notionalPrincipal": "74780.8624734314",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "440.425543379721"
+                "notionalPrincipal": 74780.8624734314,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 440.425543379721
             },
             {
                 "eventDate": "2016-04-01T00:00",
                 "eventType": "IP",
-                "payoff": "440.425543379721",
+                "payoff": 440.425543379721,
                 "currency": "USD",
-                "notionalPrincipal": "74780.8624734314",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 74780.8624734314,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2016-05-01T00:00",
                 "eventType": "PR",
-                "payoff": "724.863094424558",
+                "payoff": 724.863094424558,
                 "currency": "USD",
-                "notionalPrincipal": "74055.9993790068",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "436.221697761683"
+                "notionalPrincipal": 74055.9993790068,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 436.221697761683
             },
             {
                 "eventDate": "2016-05-01T00:00",
                 "eventType": "IP",
-                "payoff": "436.221697761683",
+                "payoff": 436.221697761683,
                 "currency": "USD",
-                "notionalPrincipal": "74055.9993790068",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 74055.9993790068,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2016-06-01T00:00",
                 "eventType": "PR",
-                "payoff": "729.091462475368",
+                "payoff": 729.091462475368,
                 "currency": "USD",
-                "notionalPrincipal": "73326.9079165315",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "431.993329710873"
+                "notionalPrincipal": 73326.9079165315,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 431.993329710873
             },
             {
                 "eventDate": "2016-06-01T00:00",
                 "eventType": "IP",
-                "payoff": "431.993329710873",
+                "payoff": 431.993329710873,
                 "currency": "USD",
-                "notionalPrincipal": "73326.9079165315",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 73326.9079165315,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2016-07-01T00:00",
                 "eventType": "PR",
-                "payoff": "733.344496006475",
+                "payoff": 733.344496006475,
                 "currency": "USD",
-                "notionalPrincipal": "72593.563420525",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "427.740296179767"
+                "notionalPrincipal": 72593.563420525,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 427.740296179767
             },
             {
                 "eventDate": "2016-07-01T00:00",
                 "eventType": "IP",
-                "payoff": "427.740296179767",
+                "payoff": 427.740296179767,
                 "currency": "USD",
-                "notionalPrincipal": "72593.563420525",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 72593.563420525,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2016-08-01T00:00",
                 "eventType": "PR",
-                "payoff": "737.622338899846",
+                "payoff": 737.622338899846,
                 "currency": "USD",
-                "notionalPrincipal": "71855.9410816251",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "423.462453286396"
+                "notionalPrincipal": 71855.9410816251,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 423.462453286396
             },
             {
                 "eventDate": "2016-08-01T00:00",
                 "eventType": "IP",
-                "payoff": "423.462453286396",
+                "payoff": 423.462453286396,
                 "currency": "USD",
-                "notionalPrincipal": "71855.9410816251",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 71855.9410816251,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2016-09-01T00:00",
                 "eventType": "PR",
-                "payoff": "741.925135876762",
+                "payoff": 741.925135876762,
                 "currency": "USD",
-                "notionalPrincipal": "71114.0159457484",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "419.15965630948"
+                "notionalPrincipal": 71114.0159457484,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 419.15965630948
             },
             {
                 "eventDate": "2016-09-01T00:00",
                 "eventType": "IP",
-                "payoff": "419.15965630948",
+                "payoff": 419.15965630948,
                 "currency": "USD",
-                "notionalPrincipal": "71114.0159457484",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 71114.0159457484,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2016-10-01T00:00",
                 "eventType": "PR",
-                "payoff": "746.253032502709",
+                "payoff": 746.253032502709,
                 "currency": "USD",
-                "notionalPrincipal": "70367.7629132457",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "414.831759683532"
+                "notionalPrincipal": 70367.7629132457,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 414.831759683532
             },
             {
                 "eventDate": "2016-10-01T00:00",
                 "eventType": "IP",
-                "payoff": "414.831759683532",
+                "payoff": 414.831759683532,
                 "currency": "USD",
-                "notionalPrincipal": "70367.7629132457",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 70367.7629132457,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2016-11-01T00:00",
                 "eventType": "PR",
-                "payoff": "750.606175192308",
+                "payoff": 750.606175192308,
                 "currency": "USD",
-                "notionalPrincipal": "69617.1567380534",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "410.478616993933"
+                "notionalPrincipal": 69617.1567380534,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 410.478616993933
             },
             {
                 "eventDate": "2016-11-01T00:00",
                 "eventType": "IP",
-                "payoff": "410.478616993933",
+                "payoff": 410.478616993933,
                 "currency": "USD",
-                "notionalPrincipal": "69617.1567380534",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 69617.1567380534,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2016-12-01T00:00",
                 "eventType": "PR",
-                "payoff": "754.984711214263",
+                "payoff": 754.984711214263,
                 "currency": "USD",
-                "notionalPrincipal": "68862.1720268391",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "406.100080971978"
+                "notionalPrincipal": 68862.1720268391,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 406.100080971978
             },
             {
                 "eventDate": "2016-12-01T00:00",
                 "eventType": "IP",
-                "payoff": "406.100080971978",
+                "payoff": 406.100080971978,
                 "currency": "USD",
-                "notionalPrincipal": "68862.1720268391",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 68862.1720268391,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2017-01-01T00:00",
                 "eventType": "PR",
-                "payoff": "759.388788696347",
+                "payoff": 759.388788696347,
                 "currency": "USD",
-                "notionalPrincipal": "68102.7832381427",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "401.696003489895"
+                "notionalPrincipal": 68102.7832381427,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 401.696003489895
             },
             {
                 "eventDate": "2017-01-01T00:00",
                 "eventType": "IP",
-                "payoff": "401.696003489895",
+                "payoff": 401.696003489895,
                 "currency": "USD",
-                "notionalPrincipal": "68102.7832381427",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 68102.7832381427,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2017-02-01T00:00",
                 "eventType": "PR",
-                "payoff": "763.818556630409",
+                "payoff": 763.818556630409,
                 "currency": "USD",
-                "notionalPrincipal": "67338.9646815123",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "397.266235555833"
+                "notionalPrincipal": 67338.9646815123,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 397.266235555833
             },
             {
                 "eventDate": "2017-02-01T00:00",
                 "eventType": "IP",
-                "payoff": "397.266235555833",
+                "payoff": 397.266235555833,
                 "currency": "USD",
-                "notionalPrincipal": "67338.9646815123",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 67338.9646815123,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2017-03-01T00:00",
                 "eventType": "PR",
-                "payoff": "768.274164877419",
+                "payoff": 768.274164877419,
                 "currency": "USD",
-                "notionalPrincipal": "66570.6905166349",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "392.810627308822"
+                "notionalPrincipal": 66570.6905166349,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 392.810627308822
             },
             {
                 "eventDate": "2017-03-01T00:00",
                 "eventType": "IP",
-                "payoff": "392.810627308822",
+                "payoff": 392.810627308822,
                 "currency": "USD",
-                "notionalPrincipal": "66570.6905166349",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 66570.6905166349,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2017-04-01T00:00",
                 "eventType": "PR",
-                "payoff": "772.755764172538",
+                "payoff": 772.755764172538,
                 "currency": "USD",
-                "notionalPrincipal": "65797.9347524624",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "388.329028013704"
+                "notionalPrincipal": 65797.9347524624,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 388.329028013704
             },
             {
                 "eventDate": "2017-04-01T00:00",
                 "eventType": "IP",
-                "payoff": "388.329028013704",
+                "payoff": 388.329028013704,
                 "currency": "USD",
-                "notionalPrincipal": "65797.9347524624",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 65797.9347524624,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2017-05-01T00:00",
                 "eventType": "PR",
-                "payoff": "777.263506130211",
+                "payoff": 777.263506130211,
                 "currency": "USD",
-                "notionalPrincipal": "65020.6712463322",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "383.821286056031"
+                "notionalPrincipal": 65020.6712463322,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 383.821286056031
             },
             {
                 "eventDate": "2017-05-01T00:00",
                 "eventType": "IP",
-                "payoff": "383.821286056031",
+                "payoff": 383.821286056031,
                 "currency": "USD",
-                "notionalPrincipal": "65020.6712463322",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 65020.6712463322,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2017-06-01T00:00",
                 "eventType": "PR",
-                "payoff": "781.797543249304",
+                "payoff": 781.797543249304,
                 "currency": "USD",
-                "notionalPrincipal": "64238.8737030829",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "379.287248936938"
+                "notionalPrincipal": 64238.8737030829,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 379.287248936938
             },
             {
                 "eventDate": "2017-06-01T00:00",
                 "eventType": "IP",
-                "payoff": "379.287248936938",
+                "payoff": 379.287248936938,
                 "currency": "USD",
-                "notionalPrincipal": "64238.8737030829",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 64238.8737030829,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2017-07-01T00:00",
                 "eventType": "PR",
-                "payoff": "786.358028918258",
+                "payoff": 786.358028918258,
                 "currency": "USD",
-                "notionalPrincipal": "63452.5156741646",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "374.726763267984"
+                "notionalPrincipal": 63452.5156741646,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 374.726763267984
             },
             {
                 "eventDate": "2017-07-01T00:00",
                 "eventType": "IP",
-                "payoff": "374.726763267984",
+                "payoff": 374.726763267984,
                 "currency": "USD",
-                "notionalPrincipal": "63452.5156741646",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 63452.5156741646,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2017-08-01T00:00",
                 "eventType": "PR",
-                "payoff": "790.945117420281",
+                "payoff": 790.945117420281,
                 "currency": "USD",
-                "notionalPrincipal": "62661.5705567443",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "370.13967476596"
+                "notionalPrincipal": 62661.5705567443,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 370.13967476596
             },
             {
                 "eventDate": "2017-08-01T00:00",
                 "eventType": "IP",
-                "payoff": "370.13967476596",
+                "payoff": 370.13967476596,
                 "currency": "USD",
-                "notionalPrincipal": "62661.5705567443",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 62661.5705567443,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2017-09-01T00:00",
                 "eventType": "PR",
-                "payoff": "795.558963938566",
+                "payoff": 795.558963938566,
                 "currency": "USD",
-                "notionalPrincipal": "61866.0115928057",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "365.525828247675"
+                "notionalPrincipal": 61866.0115928057,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 365.525828247675
             },
             {
                 "eventDate": "2017-09-01T00:00",
                 "eventType": "IP",
-                "payoff": "365.525828247675",
+                "payoff": 365.525828247675,
                 "currency": "USD",
-                "notionalPrincipal": "61866.0115928057",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 61866.0115928057,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2017-10-01T00:00",
                 "eventType": "PR",
-                "payoff": "800.199724561541",
+                "payoff": 800.199724561541,
                 "currency": "USD",
-                "notionalPrincipal": "61065.8118682442",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "360.8850676247"
+                "notionalPrincipal": 61065.8118682442,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 360.8850676247
             },
             {
                 "eventDate": "2017-10-01T00:00",
                 "eventType": "IP",
-                "payoff": "360.8850676247",
+                "payoff": 360.8850676247,
                 "currency": "USD",
-                "notionalPrincipal": "61065.8118682442",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 61065.8118682442,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2017-11-01T00:00",
                 "eventType": "PR",
-                "payoff": "804.86755628815",
+                "payoff": 804.86755628815,
                 "currency": "USD",
-                "notionalPrincipal": "60260.9443119561",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "356.217235898091"
+                "notionalPrincipal": 60260.9443119561,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 356.217235898091
             },
             {
                 "eventDate": "2017-11-01T00:00",
                 "eventType": "IP",
-                "payoff": "356.217235898091",
+                "payoff": 356.217235898091,
                 "currency": "USD",
-                "notionalPrincipal": "60260.9443119561",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 60260.9443119561,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2017-12-01T00:00",
                 "eventType": "PR",
-                "payoff": "809.562617033164",
+                "payoff": 809.562617033164,
                 "currency": "USD",
-                "notionalPrincipal": "59451.3816949229",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "351.522175153077"
+                "notionalPrincipal": 59451.3816949229,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 351.522175153077
             },
             {
                 "eventDate": "2017-12-01T00:00",
                 "eventType": "IP",
-                "payoff": "351.522175153077",
+                "payoff": 351.522175153077,
                 "currency": "USD",
-                "notionalPrincipal": "59451.3816949229",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 59451.3816949229,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2018-01-01T00:00",
                 "eventType": "PR",
-                "payoff": "814.285065632524",
+                "payoff": 814.285065632524,
                 "currency": "USD",
-                "notionalPrincipal": "58637.0966292904",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "346.799726553717"
+                "notionalPrincipal": 58637.0966292904,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 346.799726553717
             },
             {
                 "eventDate": "2018-01-01T00:00",
                 "eventType": "IP",
-                "payoff": "346.799726553717",
+                "payoff": 346.799726553717,
                 "currency": "USD",
-                "notionalPrincipal": "58637.0966292904",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 58637.0966292904,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2018-02-01T00:00",
                 "eventType": "PR",
-                "payoff": "819.035061848714",
+                "payoff": 819.035061848714,
                 "currency": "USD",
-                "notionalPrincipal": "57818.0615674417",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "342.049730337527"
+                "notionalPrincipal": 57818.0615674417,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 342.049730337527
             },
             {
                 "eventDate": "2018-02-01T00:00",
                 "eventType": "IP",
-                "payoff": "342.049730337527",
+                "payoff": 342.049730337527,
                 "currency": "USD",
-                "notionalPrincipal": "57818.0615674417",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 57818.0615674417,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2018-03-01T00:00",
                 "eventType": "PR",
-                "payoff": "823.812766376165",
+                "payoff": 823.812766376165,
                 "currency": "USD",
-                "notionalPrincipal": "56994.2488010655",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "337.272025810077"
+                "notionalPrincipal": 56994.2488010655,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 337.272025810077
             },
             {
                 "eventDate": "2018-03-01T00:00",
                 "eventType": "IP",
-                "payoff": "337.272025810077",
+                "payoff": 337.272025810077,
                 "currency": "USD",
-                "notionalPrincipal": "56994.2488010655",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 56994.2488010655,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2018-04-01T00:00",
                 "eventType": "PR",
-                "payoff": "828.618340846693",
+                "payoff": 828.618340846693,
                 "currency": "USD",
-                "notionalPrincipal": "56165.6304602188",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "332.466451339549"
+                "notionalPrincipal": 56165.6304602188,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 332.466451339549
             },
             {
                 "eventDate": "2018-04-01T00:00",
                 "eventType": "IP",
-                "payoff": "332.466451339549",
+                "payoff": 332.466451339549,
                 "currency": "USD",
-                "notionalPrincipal": "56165.6304602188",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 56165.6304602188,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2018-05-01T00:00",
                 "eventType": "PR",
-                "payoff": "833.451947834965",
+                "payoff": 833.451947834965,
                 "currency": "USD",
-                "notionalPrincipal": "55332.1785123838",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "327.632844351277"
+                "notionalPrincipal": 55332.1785123838,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 327.632844351277
             },
             {
                 "eventDate": "2018-05-01T00:00",
                 "eventType": "IP",
-                "payoff": "327.632844351277",
+                "payoff": 327.632844351277,
                 "currency": "USD",
-                "notionalPrincipal": "55332.1785123838",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 55332.1785123838,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2018-06-01T00:00",
                 "eventType": "PR",
-                "payoff": "838.313750864002",
+                "payoff": 838.313750864002,
                 "currency": "USD",
-                "notionalPrincipal": "54493.8647615198",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "322.771041322239"
+                "notionalPrincipal": 54493.8647615198,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 322.771041322239
             },
             {
                 "eventDate": "2018-06-01T00:00",
                 "eventType": "IP",
-                "payoff": "322.771041322239",
+                "payoff": 322.771041322239,
                 "currency": "USD",
-                "notionalPrincipal": "54493.8647615198",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 54493.8647615198,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2018-07-01T00:00",
                 "eventType": "PR",
-                "payoff": "843.203914410709",
+                "payoff": 843.203914410709,
                 "currency": "USD",
-                "notionalPrincipal": "53650.6608471091",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "317.880877775533"
+                "notionalPrincipal": 53650.6608471091,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 317.880877775533
             },
             {
                 "eventDate": "2018-07-01T00:00",
                 "eventType": "IP",
-                "payoff": "317.880877775533",
+                "payoff": 317.880877775533,
                 "currency": "USD",
-                "notionalPrincipal": "53650.6608471091",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 53650.6608471091,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2018-08-01T00:00",
                 "eventType": "PR",
-                "payoff": "848.122603911438",
+                "payoff": 848.122603911438,
                 "currency": "USD",
-                "notionalPrincipal": "52802.5382431977",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "312.962188274803"
+                "notionalPrincipal": 52802.5382431977,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 312.962188274803
             },
             {
                 "eventDate": "2018-08-01T00:00",
                 "eventType": "IP",
-                "payoff": "312.962188274803",
+                "payoff": 312.962188274803,
                 "currency": "USD",
-                "notionalPrincipal": "52802.5382431977",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 52802.5382431977,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2018-09-01T00:00",
                 "eventType": "PR",
-                "payoff": "853.069985767588",
+                "payoff": 853.069985767588,
                 "currency": "USD",
-                "notionalPrincipal": "51949.4682574301",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "308.014806418653"
+                "notionalPrincipal": 51949.4682574301,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 308.014806418653
             },
             {
                 "eventDate": "2018-09-01T00:00",
                 "eventType": "IP",
-                "payoff": "308.014806418653",
+                "payoff": 308.014806418653,
                 "currency": "USD",
-                "notionalPrincipal": "51949.4682574301",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 51949.4682574301,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2018-10-01T00:00",
                 "eventType": "PR",
-                "payoff": "858.046227351233",
+                "payoff": 858.046227351233,
                 "currency": "USD",
-                "notionalPrincipal": "51091.4220300789",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "303.038564835009"
+                "notionalPrincipal": 51091.4220300789,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 303.038564835009
             },
             {
                 "eventDate": "2018-10-01T00:00",
                 "eventType": "IP",
-                "payoff": "303.038564835009",
+                "payoff": 303.038564835009,
                 "currency": "USD",
-                "notionalPrincipal": "51091.4220300789",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 51091.4220300789,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2018-11-01T00:00",
                 "eventType": "PR",
-                "payoff": "863.051497010781",
+                "payoff": 863.051497010781,
                 "currency": "USD",
-                "notionalPrincipal": "50228.3705330681",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "298.03329517546"
+                "notionalPrincipal": 50228.3705330681,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 298.03329517546
             },
             {
                 "eventDate": "2018-11-01T00:00",
                 "eventType": "IP",
-                "payoff": "298.03329517546",
+                "payoff": 298.03329517546,
                 "currency": "USD",
-                "notionalPrincipal": "50228.3705330681",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 50228.3705330681,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2018-12-01T00:00",
                 "eventType": "PR",
-                "payoff": "868.085964076678",
+                "payoff": 868.085964076678,
                 "currency": "USD",
-                "notionalPrincipal": "49360.2845689914",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "292.998828109564"
+                "notionalPrincipal": 49360.2845689914,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 292.998828109564
             },
             {
                 "eventDate": "2018-12-01T00:00",
                 "eventType": "IP",
-                "payoff": "292.998828109564",
+                "payoff": 292.998828109564,
                 "currency": "USD",
-                "notionalPrincipal": "49360.2845689914",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 49360.2845689914,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2019-01-01T00:00",
                 "eventType": "PR",
-                "payoff": "873.149798867125",
+                "payoff": 873.149798867125,
                 "currency": "USD",
-                "notionalPrincipal": "48487.1347701243",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "287.934993319117"
+                "notionalPrincipal": 48487.1347701243,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 287.934993319117
             },
             {
                 "eventDate": "2019-01-01T00:00",
                 "eventType": "IP",
-                "payoff": "287.934993319117",
+                "payoff": 287.934993319117,
                 "currency": "USD",
-                "notionalPrincipal": "48487.1347701243",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 48487.1347701243,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2019-02-01T00:00",
                 "eventType": "PR",
-                "payoff": "878.24317269385",
+                "payoff": 878.24317269385,
                 "currency": "USD",
-                "notionalPrincipal": "47608.8915974304",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "282.841619492392"
+                "notionalPrincipal": 47608.8915974304,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 282.841619492392
             },
             {
                 "eventDate": "2019-02-01T00:00",
                 "eventType": "IP",
-                "payoff": "282.841619492392",
+                "payoff": 282.841619492392,
                 "currency": "USD",
-                "notionalPrincipal": "47608.8915974304",
-                "nominalInterestRate": "0.07",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 47608.8915974304,
+                "nominalInterestRate": 0.07,
+                "accruedInterest": 0.0
             }
         ]
     },
@@ -4768,245 +4768,245 @@
             {
                 "eventDate": "2013-01-01T00:00",
                 "eventType": "IED",
-                "payoff": "-5000.0",
+                "payoff": -5000.0,
                 "currency": "USD",
-                "notionalPrincipal": "5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-01-01T00:00",
                 "eventType": "PR",
-                "payoff": "400.071084163282",
+                "payoff": 400.071084163282,
                 "currency": "USD",
-                "notionalPrincipal": "4599.92891583672",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4599.92891583672,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-01-01T00:00",
                 "eventType": "IP",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "4599.92891583672",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4599.92891583672,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "PR",
-                "payoff": "368.816772625542",
+                "payoff": 368.816772625542,
                 "currency": "USD",
-                "notionalPrincipal": "4231.11214321118",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "31.2543115377399"
+                "notionalPrincipal": 4231.11214321118,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 31.2543115377399
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "IP",
-                "payoff": "31.2543115377399",
+                "payoff": 31.2543115377399,
                 "currency": "USD",
-                "notionalPrincipal": "4231.11214321118",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4231.11214321118,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "PR",
-                "payoff": "374.104806900835",
+                "payoff": 374.104806900835,
                 "currency": "USD",
-                "notionalPrincipal": "3857.00733631034",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "25.9662772624467"
+                "notionalPrincipal": 3857.00733631034,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 25.9662772624467
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "IP",
-                "payoff": "25.9662772624467",
+                "payoff": 25.9662772624467,
                 "currency": "USD",
-                "notionalPrincipal": "3857.00733631034",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3857.00733631034,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "PR",
-                "payoff": "373.864568563146",
+                "payoff": 373.864568563146,
                 "currency": "USD",
-                "notionalPrincipal": "3483.14276774719",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "26.206515600136"
+                "notionalPrincipal": 3483.14276774719,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 26.206515600136
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "IP",
-                "payoff": "26.206515600136",
+                "payoff": 26.206515600136,
                 "currency": "USD",
-                "notionalPrincipal": "3483.14276774719",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3483.14276774719,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "PR",
-                "payoff": "377.168227608232",
+                "payoff": 377.168227608232,
                 "currency": "USD",
-                "notionalPrincipal": "3105.97454013896",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "22.90285655505"
+                "notionalPrincipal": 3105.97454013896,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 22.90285655505
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "IP",
-                "payoff": "22.90285655505",
+                "payoff": 22.90285655505,
                 "currency": "USD",
-                "notionalPrincipal": "3105.97454013896",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3105.97454013896,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "PR",
-                "payoff": "378.967476328913",
+                "payoff": 378.967476328913,
                 "currency": "USD",
-                "notionalPrincipal": "2727.00706381005",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "21.1036078343689"
+                "notionalPrincipal": 2727.00706381005,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 21.1036078343689
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "IP",
-                "payoff": "21.1036078343689",
+                "payoff": 21.1036078343689,
                 "currency": "USD",
-                "notionalPrincipal": "2727.00706381005",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2727.00706381005,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "PR",
-                "payoff": "382.140078812202",
+                "payoff": 382.140078812202,
                 "currency": "USD",
-                "notionalPrincipal": "2344.86698499785",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "17.9310053510798"
+                "notionalPrincipal": 2344.86698499785,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 17.9310053510798
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "IP",
-                "payoff": "17.9310053510798",
+                "payoff": 17.9310053510798,
                 "currency": "USD",
-                "notionalPrincipal": "2344.86698499785",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2344.86698499785,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "PR",
-                "payoff": "384.138837251516",
+                "payoff": 384.138837251516,
                 "currency": "USD",
-                "notionalPrincipal": "1960.72814774633",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "15.9322469117662"
+                "notionalPrincipal": 1960.72814774633,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 15.9322469117662
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "IP",
-                "payoff": "15.9322469117662",
+                "payoff": 15.9322469117662,
                 "currency": "USD",
-                "notionalPrincipal": "1960.72814774633",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1960.72814774633,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "PR",
-                "payoff": "386.748876474485",
+                "payoff": 386.748876474485,
                 "currency": "USD",
-                "notionalPrincipal": "1573.97927127185",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "13.322207688797"
+                "notionalPrincipal": 1573.97927127185,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 13.322207688797
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "IP",
-                "payoff": "13.322207688797",
+                "payoff": 13.322207688797,
                 "currency": "USD",
-                "notionalPrincipal": "1573.97927127185",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1573.97927127185,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "PR",
-                "payoff": "389.721631420672",
+                "payoff": 389.721631420672,
                 "currency": "USD",
-                "notionalPrincipal": "1184.25763985117",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "10.3494527426094"
+                "notionalPrincipal": 1184.25763985117,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 10.3494527426094
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "IP",
-                "payoff": "10.3494527426094",
+                "payoff": 10.3494527426094,
                 "currency": "USD",
-                "notionalPrincipal": "1184.25763985117",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1184.25763985117,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "PR",
-                "payoff": "392.024621295252",
+                "payoff": 392.024621295252,
                 "currency": "USD",
-                "notionalPrincipal": "792.233018555922",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "8.0464628680299"
+                "notionalPrincipal": 792.233018555922,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 8.0464628680299
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "IP",
-                "payoff": "8.0464628680299",
+                "payoff": 8.0464628680299,
                 "currency": "USD",
-                "notionalPrincipal": "792.233018555922",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 792.233018555922,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-12-01T00:00",
                 "eventType": "PR",
-                "payoff": "394.861880753599",
+                "payoff": 394.861880753599,
                 "currency": "USD",
-                "notionalPrincipal": "397.371137802323",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "5.20920340968278"
+                "notionalPrincipal": 397.371137802323,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 5.20920340968278
             },
             {
                 "eventDate": "2013-12-01T00:00",
                 "eventType": "IP",
-                "payoff": "5.20920340968278",
+                "payoff": 5.20920340968278,
                 "currency": "USD",
-                "notionalPrincipal": "397.371137802323",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 397.371137802323,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-01-01T00:00",
                 "eventType": "IP",
-                "payoff": "2.69994636095825",
+                "payoff": 2.69994636095825,
                 "currency": "USD",
-                "notionalPrincipal": "397.371137802324",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 397.371137802324,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-01-01T00:00",
                 "eventType": "MD",
-                "payoff": "397.371137802324",
+                "payoff": 397.371137802324,
                 "currency": "USD",
-                "notionalPrincipal": "0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0"
+                "notionalPrincipal": 0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0
             }
         ]
     },
@@ -5041,218 +5041,218 @@
             {
                 "eventDate": "2013-01-01T00:00",
                 "eventType": "IED",
-                "payoff": "-6000.0",
+                "payoff": -6000.0,
                 "currency": "USD",
-                "notionalPrincipal": "6000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 6000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-01-31T00:00",
                 "eventType": "PRF",
-                "payoff": "0",
+                "payoff": 0,
                 "currency": "USD",
-                "notionalPrincipal": "6000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "39.45205479452054"
+                "notionalPrincipal": 6000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 39.45205479452054
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "PR",
-                "payoff": "526.791668421684",
+                "payoff": 526.791668421684,
                 "currency": "USD",
-                "notionalPrincipal": "5473.20833157832",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "40.7671232876712"
+                "notionalPrincipal": 5473.20833157832,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 40.7671232876712
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "IP",
-                "payoff": "40.7671232876712",
+                "payoff": 40.7671232876712,
                 "currency": "USD",
-                "notionalPrincipal": "5473.20833157832",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 5473.20833157832,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "PR",
-                "payoff": "533.969787153916",
+                "payoff": 533.969787153916,
                 "currency": "USD",
-                "notionalPrincipal": "4939.2385444243",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "33.5890045554395"
+                "notionalPrincipal": 4939.2385444243,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 33.5890045554395
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "IP",
-                "payoff": "33.5890045554395",
+                "payoff": 33.5890045554395,
                 "currency": "USD",
-                "notionalPrincipal": "4939.2385444243",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4939.2385444243,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "PR",
-                "payoff": "533.999033928061",
+                "payoff": 533.999033928061,
                 "currency": "USD",
-                "notionalPrincipal": "4405.23951049634",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "33.5597577812945"
+                "notionalPrincipal": 4405.23951049634,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 33.5597577812945
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "IP",
-                "payoff": "33.5597577812945",
+                "payoff": 33.5597577812945,
                 "currency": "USD",
-                "notionalPrincipal": "4405.23951049634",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4405.23951049634,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "PR",
-                "payoff": "538.592833284174",
+                "payoff": 538.592833284174,
                 "currency": "USD",
-                "notionalPrincipal": "3866.64667721216",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "28.9659584251814"
+                "notionalPrincipal": 3866.64667721216,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 28.9659584251814
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "IP",
-                "payoff": "28.9659584251814",
+                "payoff": 28.9659584251814,
                 "currency": "USD",
-                "notionalPrincipal": "3866.64667721216",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3866.64667721216,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "PR",
-                "payoff": "541.286781409394",
+                "payoff": 541.286781409394,
                 "currency": "USD",
-                "notionalPrincipal": "3325.35989580277",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "26.2720102999621"
+                "notionalPrincipal": 3325.35989580277,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 26.2720102999621
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "IP",
-                "payoff": "26.2720102999621",
+                "payoff": 26.2720102999621,
                 "currency": "USD",
-                "notionalPrincipal": "3325.35989580277",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3325.35989580277,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "PR",
-                "payoff": "545.69341157257",
+                "payoff": 545.69341157257,
                 "currency": "USD",
-                "notionalPrincipal": "2779.6664842302",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "21.8653801367853"
+                "notionalPrincipal": 2779.6664842302,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 21.8653801367853
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "IP",
-                "payoff": "21.8653801367853",
+                "payoff": 21.8653801367853,
                 "currency": "USD",
-                "notionalPrincipal": "2779.6664842302",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2779.6664842302,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "PR",
-                "payoff": "548.672290665819",
+                "payoff": 548.672290665819,
                 "currency": "USD",
-                "notionalPrincipal": "2230.99419356438",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "18.8865010435367"
+                "notionalPrincipal": 2230.99419356438,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 18.8865010435367
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "IP",
-                "payoff": "18.8865010435367",
+                "payoff": 18.8865010435367,
                 "currency": "USD",
-                "notionalPrincipal": "2230.99419356438",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2230.99419356438,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "PR",
-                "payoff": "552.400255818836",
+                "payoff": 552.400255818836,
                 "currency": "USD",
-                "notionalPrincipal": "1678.59393774555",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "15.1585358905196"
+                "notionalPrincipal": 1678.59393774555,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 15.1585358905196
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "IP",
-                "payoff": "15.1585358905196",
+                "payoff": 15.1585358905196,
                 "currency": "USD",
-                "notionalPrincipal": "1678.59393774555",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1678.59393774555,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "PR",
-                "payoff": "556.521461707741",
+                "payoff": 556.521461707741,
                 "currency": "USD",
-                "notionalPrincipal": "1122.0724760378",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "11.0373300016145"
+                "notionalPrincipal": 1122.0724760378,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 11.0373300016145
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "IP",
-                "payoff": "11.0373300016145",
+                "payoff": 11.0373300016145,
                 "currency": "USD",
-                "notionalPrincipal": "1122.0724760378",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1122.0724760378,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "PR",
-                "payoff": "559.934847214633",
+                "payoff": 559.934847214633,
                 "currency": "USD",
-                "notionalPrincipal": "562.137628823171",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "7.62394449472261"
+                "notionalPrincipal": 562.137628823171,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 7.62394449472261
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "IP",
-                "payoff": "7.62394449472261",
+                "payoff": 7.62394449472261,
                 "currency": "USD",
-                "notionalPrincipal": "562.137628823171",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 562.137628823171,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-12-15T00:00",
                 "eventType": "IP",
-                "payoff": "5.4211628861851",
+                "payoff": 5.4211628861851,
                 "currency": "USD",
-                "notionalPrincipal": "562.137628823171",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 562.137628823171,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-12-15T00:00",
                 "eventType": "MD",
-                "payoff": "562.137628823171",
+                "payoff": 562.137628823171,
                 "currency": "USD",
-                "notionalPrincipal": "0.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0"
+                "notionalPrincipal": 0.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0
             }
         ]
     },
@@ -5287,155 +5287,155 @@
             {
                 "eventDate": "2013-01-01T00:00",
                 "eventType": "IED",
-                "payoff": "-5000.0",
+                "payoff": -5000.0,
                 "currency": "USD",
-                "notionalPrincipal": "5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "PR",
-                "payoff": "666.027397260274",
+                "payoff": 666.027397260274,
                 "currency": "USD",
-                "notionalPrincipal": "4333.97260273973",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "33.972602739726"
+                "notionalPrincipal": 4333.97260273973,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 33.972602739726
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "IP",
-                "payoff": "33.972602739726",
+                "payoff": 33.972602739726,
                 "currency": "USD",
-                "notionalPrincipal": "4333.97260273973",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4333.97260273973,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "PR",
-                "payoff": "673.402469506474",
+                "payoff": 673.402469506474,
                 "currency": "USD",
-                "notionalPrincipal": "3660.57013323325",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "26.597530493526"
+                "notionalPrincipal": 3660.57013323325,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 26.597530493526
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "IP",
-                "payoff": "26.597530493526",
+                "payoff": 26.597530493526,
                 "currency": "USD",
-                "notionalPrincipal": "3660.57013323325",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3660.57013323325,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "PR",
-                "payoff": "675.128181012552",
+                "payoff": 675.128181012552,
                 "currency": "USD",
-                "notionalPrincipal": "2985.4419522207",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "24.8718189874479"
+                "notionalPrincipal": 2985.4419522207,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 24.8718189874479
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "IP",
-                "payoff": "24.8718189874479",
+                "payoff": 24.8718189874479,
                 "currency": "USD",
-                "notionalPrincipal": "2985.4419522207",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2985.4419522207,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "PR",
-                "payoff": "680.369696752522",
+                "payoff": 680.369696752522,
                 "currency": "USD",
-                "notionalPrincipal": "2305.07225546818",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "19.6303032474786"
+                "notionalPrincipal": 2305.07225546818,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 19.6303032474786
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "IP",
-                "payoff": "19.6303032474786",
+                "payoff": 19.6303032474786,
                 "currency": "USD",
-                "notionalPrincipal": "2305.07225546818",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2305.07225546818,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "PR",
-                "payoff": "684.338139195723",
+                "payoff": 684.338139195723,
                 "currency": "USD",
-                "notionalPrincipal": "1620.73411627246",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "15.6618608042769"
+                "notionalPrincipal": 1620.73411627246,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 15.6618608042769
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "IP",
-                "payoff": "15.6618608042769",
+                "payoff": 15.6618608042769,
                 "currency": "USD",
-                "notionalPrincipal": "1620.73411627246",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1620.73411627246,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "PR",
-                "payoff": "689.343118139578",
+                "payoff": 689.343118139578,
                 "currency": "USD",
-                "notionalPrincipal": "931.390998132877",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "10.6568818604216"
+                "notionalPrincipal": 931.390998132877,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 10.6568818604216
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "IP",
-                "payoff": "10.6568818604216",
+                "payoff": 10.6568818604216,
                 "currency": "USD",
-                "notionalPrincipal": "931.390998132877",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 931.390998132877,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "PR",
-                "payoff": "693.671644725015",
+                "payoff": 693.671644725015,
                 "currency": "USD",
-                "notionalPrincipal": "237.719353407862",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "6.32835527498503"
+                "notionalPrincipal": 237.719353407862,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 6.32835527498503
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "IP",
-                "payoff": "6.32835527498503",
+                "payoff": 6.32835527498503,
                 "currency": "USD",
-                "notionalPrincipal": "237.719353407862",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 237.719353407862,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "IP",
-                "payoff": "1.61518903137397",
+                "payoff": 1.61518903137397,
                 "currency": "USD",
-                "notionalPrincipal": "237.719353407862",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 237.719353407862,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "MD",
-                "payoff": "237.719353407862",
+                "payoff": 237.719353407862,
                 "currency": "USD",
-                "notionalPrincipal": "0.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0"
+                "notionalPrincipal": 0.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0
             }
         ]
     },
@@ -5471,218 +5471,218 @@
             {
                 "eventDate": "2013-01-01T00:00",
                 "eventType": "IED",
-                "payoff": "-5000.0",
+                "payoff": -5000.0,
                 "currency": "USD",
-                "notionalPrincipal": "5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-01-31T00:00",
                 "eventType": "PRF",
-                "payoff": "0",
+                "payoff": 0,
                 "currency": "USD",
-                "notionalPrincipal": "5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "32.87671232876712"
+                "notionalPrincipal": 5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 32.87671232876712
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "PR",
-                "payoff": "400.89399137862",
+                "payoff": 400.89399137862,
                 "currency": "USD",
-                "notionalPrincipal": "4599.10600862138",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "33.972602739726"
+                "notionalPrincipal": 4599.10600862138,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 33.972602739726
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "IP",
-                "payoff": "33.972602739726",
+                "payoff": 33.972602739726,
                 "currency": "USD",
-                "notionalPrincipal": "4599.10600862138",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4599.10600862138,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "PR",
-                "payoff": "406.641943544889",
+                "payoff": 406.641943544889,
                 "currency": "USD",
-                "notionalPrincipal": "4192.46406507649",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "28.2246505734572"
+                "notionalPrincipal": 4192.46406507649,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 28.2246505734572
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "IP",
-                "payoff": "28.2246505734572",
+                "payoff": 28.2246505734572,
                 "currency": "USD",
-                "notionalPrincipal": "4192.46406507649",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4192.46406507649,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "PR",
-                "payoff": "406.380810881662",
+                "payoff": 406.380810881662,
                 "currency": "USD",
-                "notionalPrincipal": "3786.08325419483",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "28.4857832366841"
+                "notionalPrincipal": 3786.08325419483,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 28.4857832366841
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "IP",
-                "payoff": "28.4857832366841",
+                "payoff": 28.4857832366841,
                 "currency": "USD",
-                "notionalPrincipal": "3786.08325419483",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3786.08325419483,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "PR",
-                "payoff": "409.971800118161",
+                "payoff": 409.971800118161,
                 "currency": "USD",
-                "notionalPrincipal": "3376.11145407667",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "24.8947940001852"
+                "notionalPrincipal": 3376.11145407667,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 24.8947940001852
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "IP",
-                "payoff": "24.8947940001852",
+                "payoff": 24.8947940001852,
                 "currency": "USD",
-                "notionalPrincipal": "3376.11145407667",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3376.11145407667,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "PR",
-                "payoff": "411.927535471469",
+                "payoff": 411.927535471469,
                 "currency": "USD",
-                "notionalPrincipal": "2964.1839186051",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "22.9390586468771"
+                "notionalPrincipal": 2964.1839186051,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 22.9390586468771
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "IP",
-                "payoff": "22.9390586468771",
+                "payoff": 22.9390586468771,
                 "currency": "USD",
-                "notionalPrincipal": "2964.1839186051",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2964.1839186051,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "PR",
-                "payoff": "415.376069722038",
+                "payoff": 415.376069722038,
                 "currency": "USD",
-                "notionalPrincipal": "2548.80784888316",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "19.4905243963082"
+                "notionalPrincipal": 2548.80784888316,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 19.4905243963082
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "IP",
-                "payoff": "19.4905243963082",
+                "payoff": 19.4905243963082,
                 "currency": "USD",
-                "notionalPrincipal": "2548.80784888316",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2548.80784888316,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "PR",
-                "payoff": "417.548666816345",
+                "payoff": 417.548666816345,
                 "currency": "USD",
-                "notionalPrincipal": "2131.25918206682",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "17.3179273020006"
+                "notionalPrincipal": 2131.25918206682,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 17.3179273020006
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "IP",
-                "payoff": "17.3179273020006",
+                "payoff": 17.3179273020006,
                 "currency": "USD",
-                "notionalPrincipal": "2131.25918206682",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2131.25918206682,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "PR",
-                "payoff": "420.385709812796",
+                "payoff": 420.385709812796,
                 "currency": "USD",
-                "notionalPrincipal": "1710.87347225402",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "14.4808843055499"
+                "notionalPrincipal": 1710.87347225402,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 14.4808843055499
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "IP",
-                "payoff": "14.4808843055499",
+                "payoff": 14.4808843055499,
                 "currency": "USD",
-                "notionalPrincipal": "1710.87347225402",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1710.87347225402,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "PR",
-                "payoff": "423.617015122703",
+                "payoff": 423.617015122703,
                 "currency": "USD",
-                "notionalPrincipal": "1287.25645713132",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "11.2495789956429"
+                "notionalPrincipal": 1287.25645713132,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 11.2495789956429
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "IP",
-                "payoff": "11.2495789956429",
+                "payoff": 11.2495789956429,
                 "currency": "USD",
-                "notionalPrincipal": "1287.25645713132",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1287.25645713132,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "PR",
-                "payoff": "426.120303669892",
+                "payoff": 426.120303669892,
                 "currency": "USD",
-                "notionalPrincipal": "861.136153461425",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "8.74629044845388"
+                "notionalPrincipal": 861.136153461425,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 8.74629044845388
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "IP",
-                "payoff": "8.74629044845388",
+                "payoff": 8.74629044845388,
                 "currency": "USD",
-                "notionalPrincipal": "861.136153461425",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 861.136153461425,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-11-15T00:00",
                 "eventType": "IP",
-                "payoff": "2.64239038870357",
+                "payoff": 2.64239038870357,
                 "currency": "USD",
-                "notionalPrincipal": "861.136153461425",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 861.136153461425,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-11-15T00:00",
                 "eventType": "MD",
-                "payoff": "861.136153461425",
+                "payoff": 861.136153461425,
                 "currency": "USD",
-                "notionalPrincipal": "0.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0"
+                "notionalPrincipal": 0.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0
             }
         ]
     },
@@ -5718,227 +5718,227 @@
             {
                 "eventDate": "2013-01-01T00:00",
                 "eventType": "IED",
-                "payoff": "-5000.0",
+                "payoff": -5000.0,
                 "currency": "USD",
-                "notionalPrincipal": "5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "PR",
-                "payoff": "716.027397260274",
+                "payoff": 716.027397260274,
                 "currency": "USD",
-                "notionalPrincipal": "4283.97260273973",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "33.972602739726"
+                "notionalPrincipal": 4283.97260273973,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 33.972602739726
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "IP",
-                "payoff": "33.972602739726",
+                "payoff": 33.972602739726,
                 "currency": "USD",
-                "notionalPrincipal": "4283.97260273973",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4283.97260273973,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "PR",
-                "payoff": "723.709318821543",
+                "payoff": 723.709318821543,
                 "currency": "USD",
-                "notionalPrincipal": "3560.26328391818",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "26.2906811784575"
+                "notionalPrincipal": 3560.26328391818,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 26.2906811784575
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "IP",
-                "payoff": "26.2906811784575",
+                "payoff": 26.2906811784575,
                 "currency": "USD",
-                "notionalPrincipal": "3560.26328391818",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3560.26328391818,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "PR",
-                "payoff": "725.809717961323",
+                "payoff": 725.809717961323,
                 "currency": "USD",
-                "notionalPrincipal": "2834.45356595686",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "24.190282038677"
+                "notionalPrincipal": 2834.45356595686,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 24.190282038677
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "IP",
-                "payoff": "24.190282038677",
+                "payoff": 24.190282038677,
                 "currency": "USD",
-                "notionalPrincipal": "2834.45356595686",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2834.45356595686,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "PR",
-                "payoff": "731.362497100558",
+                "payoff": 731.362497100558,
                 "currency": "USD",
-                "notionalPrincipal": "2103.0910688563",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "18.6375028994424"
+                "notionalPrincipal": 2103.0910688563,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 18.6375028994424
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "IP",
-                "payoff": "18.6375028994424",
+                "payoff": 18.6375028994424,
                 "currency": "USD",
-                "notionalPrincipal": "2103.0910688563",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2103.0910688563,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "PR",
-                "payoff": "735.710504518456",
+                "payoff": 735.710504518456,
                 "currency": "USD",
-                "notionalPrincipal": "1367.38056433785",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "14.2894954815442"
+                "notionalPrincipal": 1367.38056433785,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 14.2894954815442
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "IP",
-                "payoff": "14.2894954815442",
+                "payoff": 14.2894954815442,
                 "currency": "USD",
-                "notionalPrincipal": "1367.38056433785",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1367.38056433785,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "PR",
-                "payoff": "741.009004508464",
+                "payoff": 741.009004508464,
                 "currency": "USD",
-                "notionalPrincipal": "626.371559829384",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "8.99099549153653"
+                "notionalPrincipal": 626.371559829384,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 8.99099549153653
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "IP",
-                "payoff": "8.99099549153653",
+                "payoff": 8.99099549153653,
                 "currency": "USD",
-                "notionalPrincipal": "626.371559829384",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 626.371559829384,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "PR",
-                "payoff": "626.371559829384",
+                "payoff": 626.371559829384,
                 "currency": "USD",
-                "notionalPrincipal": "0.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "4.25589443390924"
+                "notionalPrincipal": 0.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 4.25589443390924
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "IP",
-                "payoff": "4.25589443390924",
+                "payoff": 4.25589443390924,
                 "currency": "USD",
-                "notionalPrincipal": "0.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 0.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "PR",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "0.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 0.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "IP",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "0.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 0.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "PR",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "0.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 0.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "IP",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "0.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 0.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "PR",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "0.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 0.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "IP",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "0.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 0.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-12-01T00:00",
                 "eventType": "PR",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "0.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 0.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-12-01T00:00",
                 "eventType": "IP",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "0.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 0.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-01-01T00:00",
                 "eventType": "IP",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "0.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 0.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-01-01T00:00",
                 "eventType": "MD",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "0.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 0.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             }
         ]
     },
@@ -5974,164 +5974,164 @@
             {
                 "eventDate": "2013-01-01T00:00",
                 "eventType": "IED",
-                "payoff": "-5000.0",
+                "payoff": -5000.0,
                 "currency": "USD",
-                "notionalPrincipal": "5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "IPCI",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "5198.35616438356",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 5198.35616438356,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "IP",
-                "payoff": "70.6406755488835",
+                "payoff": 70.6406755488835,
                 "currency": "USD",
-                "notionalPrincipal": "5198.35616438356",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 5198.35616438356,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-09-30T00:00",
                 "eventType": "PRF",
-                "payoff": "0",
+                "payoff": 0,
                 "currency": "USD",
-                "notionalPrincipal": "5198.35616438356",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "33.04160630512292"
+                "notionalPrincipal": 5198.35616438356,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 33.04160630512292
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "PR",
-                "payoff": "728.337163175356",
+                "payoff": 728.337163175356,
                 "currency": "USD",
-                "notionalPrincipal": "4470.01900120821",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "34.1809720397823"
+                "notionalPrincipal": 4470.01900120821,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 34.1809720397823
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "IP",
-                "payoff": "34.1809720397823",
+                "payoff": 34.1809720397823,
                 "currency": "USD",
-                "notionalPrincipal": "4470.01900120821",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4470.01900120821,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "PR",
-                "payoff": "732.146499261723",
+                "payoff": 732.146499261723,
                 "currency": "USD",
-                "notionalPrincipal": "3737.87250194648",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "30.3716359534147"
+                "notionalPrincipal": 3737.87250194648,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 30.3716359534147
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "IP",
-                "payoff": "30.3716359534147",
+                "payoff": 30.3716359534147,
                 "currency": "USD",
-                "notionalPrincipal": "3737.87250194648",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3737.87250194648,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-12-01T00:00",
                 "eventType": "PR",
-                "payoff": "737.940343421517",
+                "payoff": 737.940343421517,
                 "currency": "USD",
-                "notionalPrincipal": "2999.93215852496",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "24.5777917936207"
+                "notionalPrincipal": 2999.93215852496,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 24.5777917936207
             },
             {
                 "eventDate": "2013-12-01T00:00",
                 "eventType": "IP",
-                "payoff": "24.5777917936207",
+                "payoff": 24.5777917936207,
                 "currency": "USD",
-                "notionalPrincipal": "2999.93215852496",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2999.93215852496,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-01-01T00:00",
                 "eventType": "PR",
-                "payoff": "742.135034521599",
+                "payoff": 742.135034521599,
                 "currency": "USD",
-                "notionalPrincipal": "2257.79712400337",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "20.3831006935395"
+                "notionalPrincipal": 2257.79712400337,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 20.3831006935395
             },
             {
                 "eventDate": "2014-01-01T00:00",
                 "eventType": "IP",
-                "payoff": "20.3831006935395",
+                "payoff": 20.3831006935395,
                 "currency": "USD",
-                "notionalPrincipal": "2257.79712400337",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2257.79712400337,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-02-01T00:00",
                 "eventType": "PR",
-                "payoff": "747.177486263006",
+                "payoff": 747.177486263006,
                 "currency": "USD",
-                "notionalPrincipal": "1510.61963774036",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "15.3406489521325"
+                "notionalPrincipal": 1510.61963774036,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 15.3406489521325
             },
             {
                 "eventDate": "2014-02-01T00:00",
                 "eventType": "IP",
-                "payoff": "15.3406489521325",
+                "payoff": 15.3406489521325,
                 "currency": "USD",
-                "notionalPrincipal": "1510.61963774036",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1510.61963774036,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-03-01T00:00",
                 "eventType": "PR",
-                "payoff": "753.247483191745",
+                "payoff": 753.247483191745,
                 "currency": "USD",
-                "notionalPrincipal": "757.372154548616",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "9.2706520233929"
+                "notionalPrincipal": 757.372154548616,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 9.2706520233929
             },
             {
                 "eventDate": "2014-03-01T00:00",
                 "eventType": "IP",
-                "payoff": "9.2706520233929",
+                "payoff": 9.2706520233929,
                 "currency": "USD",
-                "notionalPrincipal": "757.372154548616",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 757.372154548616,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-04-01T00:00",
                 "eventType": "IP",
-                "payoff": "5.1459806665221",
+                "payoff": 5.1459806665221,
                 "currency": "USD",
-                "notionalPrincipal": "757.372154548616",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 757.372154548616,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-04-01T00:00",
                 "eventType": "MD",
-                "payoff": "757.372154548616",
+                "payoff": 757.372154548616,
                 "currency": "USD",
-                "notionalPrincipal": "0.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0"
+                "notionalPrincipal": 0.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0
             }
         ]
     },
@@ -6512,20 +6512,20 @@
             {
                 "eventDate": "2013-01-01T00:00",
                 "eventType": "IED",
-                "payoff": "-5000.0",
+                "payoff": -5000.0,
                 "currency": "USD",
-                "notionalPrincipal": "5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "IP",
-                "payoff": "33.972602739726",
+                "payoff": 33.972602739726,
                 "currency": "USD",
-                "notionalPrincipal": "5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-02-28T00:00:00",
@@ -6539,254 +6539,254 @@
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "PR",
-                "payoff": "442.088030567905",
+                "payoff": 442.088030567905,
                 "currency": "USD",
-                "notionalPrincipal": "4557.911969432",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "30.6849315068493"
+                "notionalPrincipal": 4557.911969432,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 30.6849315068493
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "IP",
-                "payoff": "30.6849315068493",
+                "payoff": 30.6849315068493,
                 "currency": "USD",
-                "notionalPrincipal": "4557.911969432",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4557.911969432,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "PR",
-                "payoff": "441.804135542722",
+                "payoff": 441.804135542722,
                 "currency": "USD",
-                "notionalPrincipal": "4116.10783388937",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "30.9688265320318"
+                "notionalPrincipal": 4116.10783388937,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 30.9688265320318
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "IP",
-                "payoff": "30.9688265320318",
+                "payoff": 30.9688265320318,
                 "currency": "USD",
-                "notionalPrincipal": "4116.10783388937",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4116.10783388937,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "RRF",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "4116.10783388937",
-                "nominalInterestRate": "0.06",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4116.10783388937,
+                "nominalInterestRate": 0.06,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "PRF",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "4116.10783388937",
-                "nominalInterestRate": "0.06",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4116.10783388937,
+                "nominalInterestRate": 0.06,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "PR",
-                "payoff": "448.592103183357",
+                "payoff": 448.592103183357,
                 "currency": "USD",
-                "notionalPrincipal": "3667.51573070602",
-                "nominalInterestRate": "0.06",
-                "accruedInterest": "20.2986139753449"
+                "notionalPrincipal": 3667.51573070602,
+                "nominalInterestRate": 0.06,
+                "accruedInterest": 20.2986139753449
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "IP",
-                "payoff": "20.2986139753449",
+                "payoff": 20.2986139753449,
                 "currency": "USD",
-                "notionalPrincipal": "3667.51573070602",
-                "nominalInterestRate": "0.06",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3667.51573070602,
+                "nominalInterestRate": 0.06,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "PR",
-                "payoff": "450.201458914556",
+                "payoff": 450.201458914556,
                 "currency": "USD",
-                "notionalPrincipal": "3217.31427179146",
-                "nominalInterestRate": "0.06",
-                "accruedInterest": "18.6892582441457"
+                "notionalPrincipal": 3217.31427179146,
+                "nominalInterestRate": 0.06,
+                "accruedInterest": 18.6892582441457
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "IP",
-                "payoff": "18.6892582441457",
+                "payoff": 18.6892582441457,
                 "currency": "USD",
-                "notionalPrincipal": "3217.31427179146",
-                "nominalInterestRate": "0.06",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3217.31427179146,
+                "nominalInterestRate": 0.06,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "PR",
-                "payoff": "453.024509790963",
+                "payoff": 453.024509790963,
                 "currency": "USD",
-                "notionalPrincipal": "2764.2897620004",
-                "nominalInterestRate": "0.06",
-                "accruedInterest": "15.8662073677387"
+                "notionalPrincipal": 2764.2897620004,
+                "nominalInterestRate": 0.06,
+                "accruedInterest": 15.8662073677387
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "IP",
-                "payoff": "15.8662073677387",
+                "payoff": 15.8662073677387,
                 "currency": "USD",
-                "notionalPrincipal": "2764.2897620004",
-                "nominalInterestRate": "0.06",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2764.2897620004,
+                "nominalInterestRate": 0.06,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "RR",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "2764.2897620004",
-                "nominalInterestRate": "0.111654320987654",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2764.2897620004,
+                "nominalInterestRate": 0.111654320987654,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "PRF",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "2764.2897620004",
-                "nominalInterestRate": "0.11165432098765432",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2764.2897620004,
+                "nominalInterestRate": 0.11165432098765432,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "PR",
-                "payoff": "449.770379260527",
+                "payoff": 449.770379260527,
                 "currency": "USD",
-                "notionalPrincipal": "2314.51938273997",
-                "nominalInterestRate": "0.111654320987654",
-                "accruedInterest": "26.2136761316931"
+                "notionalPrincipal": 2314.51938273997,
+                "nominalInterestRate": 0.111654320987654,
+                "accruedInterest": 26.2136761316931
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "IP",
-                "payoff": "26.2136761316931",
+                "payoff": 26.2136761316931,
                 "currency": "USD",
-                "notionalPrincipal": "2314.51938273997",
-                "nominalInterestRate": "0.111654320987654",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2314.51938273997,
+                "nominalInterestRate": 0.111654320987654,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "PR",
-                "payoff": "454.035538151479",
+                "payoff": 454.035538151479,
                 "currency": "USD",
-                "notionalPrincipal": "1860.48384458849",
-                "nominalInterestRate": "0.111654320987654",
-                "accruedInterest": "21.948517240741"
+                "notionalPrincipal": 1860.48384458849,
+                "nominalInterestRate": 0.111654320987654,
+                "accruedInterest": 21.948517240741
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "IP",
-                "payoff": "21.948517240741",
+                "payoff": 21.948517240741,
                 "currency": "USD",
-                "notionalPrincipal": "1860.48384458849",
-                "nominalInterestRate": "0.111654320987654",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1860.48384458849,
+                "nominalInterestRate": 0.111654320987654,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "PR",
-                "payoff": "458.910269607889",
+                "payoff": 458.910269607889,
                 "currency": "USD",
-                "notionalPrincipal": "1401.5735749806",
-                "nominalInterestRate": "0.111654320987654",
-                "accruedInterest": "17.0737857843311"
+                "notionalPrincipal": 1401.5735749806,
+                "nominalInterestRate": 0.111654320987654,
+                "accruedInterest": 17.0737857843311
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "IP",
-                "payoff": "17.0737857843311",
+                "payoff": 17.0737857843311,
                 "currency": "USD",
-                "notionalPrincipal": "1401.5735749806",
-                "nominalInterestRate": "0.111654320987654",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1401.5735749806,
+                "nominalInterestRate": 0.111654320987654,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "RR",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "1401.5735749806",
-                "nominalInterestRate": "0.112765432098765",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1401.5735749806,
+                "nominalInterestRate": 0.112765432098765,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "PRF",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "1401.5735749806",
-                "nominalInterestRate": "0.112765432098765",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1401.5735749806,
+                "nominalInterestRate": 0.112765432098765,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "PR",
-                "payoff": "462.64848659516",
+                "payoff": 462.64848659516,
                 "currency": "USD",
-                "notionalPrincipal": "938.925088385442",
-                "nominalInterestRate": "0.112765432098765",
-                "accruedInterest": "13.4233439556928"
+                "notionalPrincipal": 938.925088385442,
+                "nominalInterestRate": 0.112765432098765,
+                "accruedInterest": 13.4233439556928
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "IP",
-                "payoff": "13.4233439556928",
+                "payoff": 13.4233439556928,
                 "currency": "USD",
-                "notionalPrincipal": "938.925088385442",
-                "nominalInterestRate": "0.112765432098765",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 938.925088385442,
+                "nominalInterestRate": 0.112765432098765,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-12-01T00:00",
                 "eventType": "PR",
-                "payoff": "467.369505074127",
+                "payoff": 467.369505074127,
                 "currency": "USD",
-                "notionalPrincipal": "471.555583311315",
-                "nominalInterestRate": "0.112765432098765",
-                "accruedInterest": "8.70232547672514"
+                "notionalPrincipal": 471.555583311315,
+                "nominalInterestRate": 0.112765432098765,
+                "accruedInterest": 8.70232547672514
             },
             {
                 "eventDate": "2013-12-01T00:00",
                 "eventType": "IP",
-                "payoff": "8.70232547672514",
+                "payoff": 8.70232547672514,
                 "currency": "USD",
-                "notionalPrincipal": "471.555583311315",
-                "nominalInterestRate": "0.112765432098765",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 471.555583311315,
+                "nominalInterestRate": 0.112765432098765,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-01-01T00:00",
                 "eventType": "IP",
-                "payoff": "4.5162472395377",
+                "payoff": 4.5162472395377,
                 "currency": "USD",
-                "notionalPrincipal": "471.555583311315",
-                "nominalInterestRate": "0.112765432098765",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 471.555583311315,
+                "nominalInterestRate": 0.112765432098765,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-01-01T00:00",
                 "eventType": "MD",
-                "payoff": "471.555583311315",
+                "payoff": 471.555583311315,
                 "currency": "USD",
-                "notionalPrincipal": "0.0",
-                "nominalInterestRate": "0.112765432098765",
-                "accruedInterest": "0"
+                "notionalPrincipal": 0.0,
+                "nominalInterestRate": 0.112765432098765,
+                "accruedInterest": 0
             }
         ]
     },
@@ -6822,164 +6822,164 @@
             {
                 "eventDate": "2013-01-01T00:00",
                 "eventType": "IED",
-                "payoff": "-5000.0",
+                "payoff": -5000.0,
                 "currency": "USD",
-                "notionalPrincipal": "5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-06-15T00:00",
                 "eventType": "IPCI",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "5180.82191780822",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 5180.82191780822,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "IP",
-                "payoff": "88.5707637455433",
+                "payoff": 88.5707637455433,
                 "currency": "USD",
-                "notionalPrincipal": "5180.82191780822",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 5180.82191780822,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-09-30T00:00",
                 "eventType": "PRF",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "5180.82191780822",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "32.9301557515"
+                "notionalPrincipal": 5180.82191780822,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 32.9301557515
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "PR",
-                "payoff": "725.880455130493",
+                "payoff": 725.880455130493,
                 "currency": "USD",
-                "notionalPrincipal": "4454.94146267773",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "34.0656783636705"
+                "notionalPrincipal": 4454.94146267773,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 34.0656783636705
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "IP",
-                "payoff": "34.0656783636705",
+                "payoff": 34.0656783636705,
                 "currency": "USD",
-                "notionalPrincipal": "4454.94146267773",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4454.94146267773,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "PR",
-                "payoff": "729.676942186107",
+                "payoff": 729.676942186107,
                 "currency": "USD",
-                "notionalPrincipal": "3725.26452049162",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "30.2691913080569"
+                "notionalPrincipal": 3725.26452049162,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 30.2691913080569
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "IP",
-                "payoff": "30.2691913080569",
+                "payoff": 30.2691913080569,
                 "currency": "USD",
-                "notionalPrincipal": "3725.26452049162",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3725.26452049162,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-12-01T00:00",
                 "eventType": "PR",
-                "payoff": "735.45124349641",
+                "payoff": 735.45124349641,
                 "currency": "USD",
-                "notionalPrincipal": "2989.81327699521",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "24.4948899977531"
+                "notionalPrincipal": 2989.81327699521,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 24.4948899977531
             },
             {
                 "eventDate": "2013-12-01T00:00",
                 "eventType": "IP",
-                "payoff": "24.4948899977531",
+                "payoff": 24.4948899977531,
                 "currency": "USD",
-                "notionalPrincipal": "2989.81327699521",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2989.81327699521,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-01-01T00:00",
                 "eventType": "PR",
-                "payoff": "739.6317857491",
+                "payoff": 739.6317857491,
                 "currency": "USD",
-                "notionalPrincipal": "2250.18149124611",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "20.3143477450633"
+                "notionalPrincipal": 2250.18149124611,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 20.3143477450633
             },
             {
                 "eventDate": "2014-01-01T00:00",
                 "eventType": "IP",
-                "payoff": "20.3143477450633",
+                "payoff": 20.3143477450633,
                 "currency": "USD",
-                "notionalPrincipal": "2250.18149124611",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2250.18149124611,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-02-01T00:00",
                 "eventType": "PR",
-                "payoff": "744.657229115286",
+                "payoff": 744.657229115286,
                 "currency": "USD",
-                "notionalPrincipal": "1505.52426213082",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "15.2889043788777"
+                "notionalPrincipal": 1505.52426213082,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 15.2889043788777
             },
             {
                 "eventDate": "2014-02-01T00:00",
                 "eventType": "IP",
-                "payoff": "15.2889043788777",
+                "payoff": 15.2889043788777,
                 "currency": "USD",
-                "notionalPrincipal": "1505.52426213082",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1505.52426213082,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-03-01T00:00",
                 "eventType": "PR",
-                "payoff": "750.706751721087",
+                "payoff": 750.706751721087,
                 "currency": "USD",
-                "notionalPrincipal": "754.817510409736",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "9.23938177307683"
+                "notionalPrincipal": 754.817510409736,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 9.23938177307683
             },
             {
                 "eventDate": "2014-03-01T00:00",
                 "eventType": "IP",
-                "payoff": "9.23938177307683",
+                "payoff": 9.23938177307683,
                 "currency": "USD",
-                "notionalPrincipal": "754.817510409736",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 754.817510409736,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-04-01T00:00",
                 "eventType": "IP",
-                "payoff": "5.12862308442779",
+                "payoff": 5.12862308442779,
                 "currency": "USD",
-                "notionalPrincipal": "754.817510409736",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 754.817510409736,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-04-01T00:00",
                 "eventType": "MD",
-                "payoff": "754.817510409736",
+                "payoff": 754.817510409736,
                 "currency": "USD",
-                "notionalPrincipal": "0.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0"
+                "notionalPrincipal": 0.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0
             }
         ]
     },
@@ -7016,155 +7016,155 @@
             {
                 "eventDate":           "2013-05-15T00:00",
                 "eventType":           "PRD",
-                "payoff":              "-3010.3595748728",
+                "payoff":              -3010.3595748728,
                 "currency":            "USD",
-                "notionalPrincipal":   "3376.1114540766",
-                "nominalInterestRate": "0.08",
-                "accruedInterest":     "10.3595748727"
+                "notionalPrincipal":   3376.1114540766,
+                "nominalInterestRate": 0.08,
+                "accruedInterest":     10.3595748727
             },
             {
                 "eventDate":           "2013-06-01T00:00",
                 "eventType":           "PR",
-                "payoff":              "411.9275354714",
+                "payoff":              411.9275354714,
                 "currency":            "USD",
-                "notionalPrincipal":   "2964.1839186051",
-                "nominalInterestRate": "0.08",
-                "accruedInterest":     "22.9390586468"
+                "notionalPrincipal":   2964.1839186051,
+                "nominalInterestRate": 0.08,
+                "accruedInterest":     22.9390586468
             },
             {
                 "eventDate":           "2013-06-01T00:00",
                 "eventType":           "IP",
-                "payoff":              "22.9390586468",
+                "payoff":              22.9390586468,
                 "currency":            "USD",
-                "notionalPrincipal":   "2964.1839186051",
-                "nominalInterestRate": "0.08",
-                "accruedInterest":     "0.0"
+                "notionalPrincipal":   2964.1839186051,
+                "nominalInterestRate": 0.08,
+                "accruedInterest":     0.0
             },
             {
                 "eventDate":           "2013-07-01T00:00",
                 "eventType":           "PR",
-                "payoff":              "415.376069722",
+                "payoff":              415.376069722,
                 "currency":            "USD",
-                "notionalPrincipal":   "2548.8078488831",
-                "nominalInterestRate": "0.08",
-                "accruedInterest":     "19.4905243963"
+                "notionalPrincipal":   2548.8078488831,
+                "nominalInterestRate": 0.08,
+                "accruedInterest":     19.4905243963
             },
             {
                 "eventDate":           "2013-07-01T00:00",
                 "eventType":           "IP",
-                "payoff":              "19.4905243963",
+                "payoff":              19.4905243963,
                 "currency":            "USD",
-                "notionalPrincipal":   "2548.8078488831",
-                "nominalInterestRate": "0.08",
-                "accruedInterest":     "0.0"
+                "notionalPrincipal":   2548.8078488831,
+                "nominalInterestRate": 0.08,
+                "accruedInterest":     0.0
             },
             {
                 "eventDate":           "2013-08-01T00:00",
                 "eventType":           "PR",
-                "payoff":              "417.5486668163",
+                "payoff":              417.5486668163,
                 "currency":            "USD",
-                "notionalPrincipal":   "2131.2591820668",
-                "nominalInterestRate": "0.08",
-                "accruedInterest":     "17.317927302"
+                "notionalPrincipal":   2131.2591820668,
+                "nominalInterestRate": 0.08,
+                "accruedInterest":     17.317927302
             },
             {
                 "eventDate":           "2013-08-01T00:00",
                 "eventType":           "IP",
-                "payoff":              "17.317927302",
+                "payoff":              17.317927302,
                 "currency":            "USD",
-                "notionalPrincipal":   "2131.2591820668",
-                "nominalInterestRate": "0.08",
-                "accruedInterest":     "0.0"
+                "notionalPrincipal":   2131.2591820668,
+                "nominalInterestRate": 0.08,
+                "accruedInterest":     0.0
             },
             {
                 "eventDate":           "2013-09-01T00:00",
                 "eventType":           "PR",
-                "payoff":              "420.3857098127",
+                "payoff":              420.3857098127,
                 "currency":            "USD",
-                "notionalPrincipal":   "1710.873472254",
-                "nominalInterestRate": "0.08",
-                "accruedInterest":     "14.4808843055"
+                "notionalPrincipal":   1710.873472254,
+                "nominalInterestRate": 0.08,
+                "accruedInterest":     14.4808843055
             },
             {
                 "eventDate":           "2013-09-01T00:00",
                 "eventType":           "IP",
-                "payoff":              "14.4808843055",
+                "payoff":              14.4808843055,
                 "currency":            "USD",
-                "notionalPrincipal":   "1710.873472254",
-                "nominalInterestRate": "0.08",
-                "accruedInterest":     "0.0"
+                "notionalPrincipal":   1710.873472254,
+                "nominalInterestRate": 0.08,
+                "accruedInterest":     0.0
             },
             {
                 "eventDate":           "2013-10-01T00:00",
                 "eventType":           "PR",
-                "payoff":              "423.6170151227",
+                "payoff":              423.6170151227,
                 "currency":            "USD",
-                "notionalPrincipal":   "1287.2564571313",
-                "nominalInterestRate": "0.08",
-                "accruedInterest":     "11.2495789956"
+                "notionalPrincipal":   1287.2564571313,
+                "nominalInterestRate": 0.08,
+                "accruedInterest":     11.2495789956
             },
             {
                 "eventDate":           "2013-10-01T00:00",
                 "eventType":           "IP",
-                "payoff":              "11.2495789956",
+                "payoff":              11.2495789956,
                 "currency":            "USD",
-                "notionalPrincipal":   "1287.2564571313",
-                "nominalInterestRate": "0.08",
-                "accruedInterest":     "0.0"
+                "notionalPrincipal":   1287.2564571313,
+                "nominalInterestRate": 0.08,
+                "accruedInterest":     0.0
             },
             {
                 "eventDate":           "2013-11-01T00:00",
                 "eventType":           "PR",
-                "payoff":              "426.1203036698",
+                "payoff":              426.1203036698,
                 "currency":            "USD",
-                "notionalPrincipal":   "861.1361534614",
-                "nominalInterestRate": "0.08",
-                "accruedInterest":     "8.7462904484"
+                "notionalPrincipal":   861.1361534614,
+                "nominalInterestRate": 0.08,
+                "accruedInterest":     8.7462904484
             },
             {
                 "eventDate":           "2013-11-01T00:00",
                 "eventType":           "IP",
-                "payoff":              "8.7462904484",
+                "payoff":              8.7462904484,
                 "currency":            "USD",
-                "notionalPrincipal":   "861.1361534614",
-                "nominalInterestRate": "0.08",
-                "accruedInterest":     "0.0"
+                "notionalPrincipal":   861.1361534614,
+                "nominalInterestRate": 0.08,
+                "accruedInterest":     0.0
             },
             {
                 "eventDate":           "2013-12-01T00:00",
                 "eventType":           "PR",
-                "payoff":              "429.2043289996",
+                "payoff":              429.2043289996,
                 "currency":            "USD",
-                "notionalPrincipal":   "431.9318244617",
-                "nominalInterestRate": "0.08",
-                "accruedInterest":     "5.6622651186"
+                "notionalPrincipal":   431.9318244617,
+                "nominalInterestRate": 0.08,
+                "accruedInterest":     5.6622651186
             },
             {
                 "eventDate":           "2013-12-01T00:00",
                 "eventType":           "IP",
-                "payoff":              "5.6622651186",
+                "payoff":              5.6622651186,
                 "currency":            "USD",
-                "notionalPrincipal":   "431.9318244617",
-                "nominalInterestRate": "0.08",
-                "accruedInterest":     "0.0"
+                "notionalPrincipal":   431.9318244617,
+                "nominalInterestRate": 0.08,
+                "accruedInterest":     0.0
             },
             {
                 "eventDate":           "2014-01-01T00:00",
                 "eventType":           "IP",
-                "payoff":              "2.9347696566",
+                "payoff":              2.9347696566,
                 "currency":            "USD",
-                "notionalPrincipal":   "431.9318244617",
-                "nominalInterestRate": "0.08",
-                "accruedInterest":     "0.0"
+                "notionalPrincipal":   431.9318244617,
+                "nominalInterestRate": 0.08,
+                "accruedInterest":     0.0
             },
             {
                 "eventDate":           "2014-01-01T00:00",
                 "eventType":           "MD",
-                "payoff":              "431.9318244617",
+                "payoff":              431.9318244617,
                 "currency":            "USD",
-                "notionalPrincipal":   "0.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest":     "0.0"
+                "notionalPrincipal":   0.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest":     0.0
             }
         ]
     },
@@ -7201,137 +7201,137 @@
             {
                 "eventDate": "2013-01-01T00:00",
                 "eventType": "IED",
-                "payoff": "-5000.0",
+                "payoff": -5000.0,
                 "currency": "USD",
-                "notionalPrincipal": "5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-01-31T00:00",
                 "eventType": "PRF",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "32.8767123287"
+                "notionalPrincipal": 5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 32.8767123287
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "PR",
-                "payoff": "400.89399137862",
+                "payoff": 400.89399137862,
                 "currency": "USD",
-                "notionalPrincipal": "4599.10600862138",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "33.972602739726"
+                "notionalPrincipal": 4599.10600862138,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 33.972602739726
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "IP",
-                "payoff": "33.972602739726",
+                "payoff": 33.972602739726,
                 "currency": "USD",
-                "notionalPrincipal": "4599.10600862138",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4599.10600862138,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "PR",
-                "payoff": "406.641943544889",
+                "payoff": 406.641943544889,
                 "currency": "USD",
-                "notionalPrincipal": "4192.46406507649",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "28.2246505734572"
+                "notionalPrincipal": 4192.46406507649,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 28.2246505734572
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "IP",
-                "payoff": "28.2246505734572",
+                "payoff": 28.2246505734572,
                 "currency": "USD",
-                "notionalPrincipal": "4192.46406507649",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4192.46406507649,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "PR",
-                "payoff": "406.380810881662",
+                "payoff": 406.380810881662,
                 "currency": "USD",
-                "notionalPrincipal": "3786.08325419483",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "28.4857832366841"
+                "notionalPrincipal": 3786.08325419483,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 28.4857832366841
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "IP",
-                "payoff": "28.4857832366841",
+                "payoff": 28.4857832366841,
                 "currency": "USD",
-                "notionalPrincipal": "3786.08325419483",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3786.08325419483,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "PR",
-                "payoff": "409.971800118161",
+                "payoff": 409.971800118161,
                 "currency": "USD",
-                "notionalPrincipal": "3376.11145407667",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "24.8947940001852"
+                "notionalPrincipal": 3376.11145407667,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 24.8947940001852
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "IP",
-                "payoff": "24.8947940001852",
+                "payoff": 24.8947940001852,
                 "currency": "USD",
-                "notionalPrincipal": "3376.11145407667",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3376.11145407667,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "PR",
-                "payoff": "411.927535471469",
+                "payoff": 411.927535471469,
                 "currency": "USD",
-                "notionalPrincipal": "2964.1839186051",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "22.9390586468771"
+                "notionalPrincipal": 2964.1839186051,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 22.9390586468771
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "IP",
-                "payoff": "22.9390586468771",
+                "payoff": 22.9390586468771,
                 "currency": "USD",
-                "notionalPrincipal": "2964.1839186051",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2964.1839186051,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "PR",
-                "payoff": "415.376069722038",
+                "payoff": 415.376069722038,
                 "currency": "USD",
-                "notionalPrincipal": "2548.80784888316",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "19.4905243963082"
+                "notionalPrincipal": 2548.80784888316,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 19.4905243963082
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "IP",
-                "payoff": "19.4905243963082",
+                "payoff": 19.4905243963082,
                 "currency": "USD",
-                "notionalPrincipal": "2548.80784888316",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2548.80784888316,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-07-01T23:59:59",
                 "eventType": "TD",
-                "payoff": "2600.55864281619",
+                "payoff": 2600.55864281619,
                 "currency": "USD",
-                "notionalPrincipal": "0.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 0.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             }
         ]
     },
@@ -7366,236 +7366,236 @@
             {
                 "eventDate": "2013-01-01T00:00",
                 "eventType": "IED",
-                "payoff": "5000.0",
+                "payoff": 5000.0,
                 "currency": "USD",
-                "notionalPrincipal": "-5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-01-31T00:00",
                 "eventType": "PRF",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "-5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "-32.8767123288"
+                "notionalPrincipal": -5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": -32.8767123288
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "PR",
-                "payoff": "-400.89399137862",
+                "payoff": -400.89399137862,
                 "currency": "USD",
-                "notionalPrincipal": "-4599.10600862138",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "-33.972602739726"
+                "notionalPrincipal": -4599.10600862138,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": -33.972602739726
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "IP",
-                "payoff": "-33.972602739726",
+                "payoff": -33.972602739726,
                 "currency": "USD",
-                "notionalPrincipal": "-4599.10600862138",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -4599.10600862138,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "PR",
-                "payoff": "-406.641943544889",
+                "payoff": -406.641943544889,
                 "currency": "USD",
-                "notionalPrincipal": "-4192.46406507649",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "-28.2246505734572"
+                "notionalPrincipal": -4192.46406507649,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": -28.2246505734572
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "IP",
-                "payoff": "-28.2246505734572",
+                "payoff": -28.2246505734572,
                 "currency": "USD",
-                "notionalPrincipal": "-4192.46406507649",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -4192.46406507649,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "PR",
-                "payoff": "-406.380810881662",
+                "payoff": -406.380810881662,
                 "currency": "USD",
-                "notionalPrincipal": "-3786.08325419483",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "-28.4857832366841"
+                "notionalPrincipal": -3786.08325419483,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": -28.4857832366841
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "IP",
-                "payoff": "-28.4857832366841",
+                "payoff": -28.4857832366841,
                 "currency": "USD",
-                "notionalPrincipal": "-3786.08325419483",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -3786.08325419483,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "PR",
-                "payoff": "-409.971800118161",
+                "payoff": -409.971800118161,
                 "currency": "USD",
-                "notionalPrincipal": "-3376.11145407667",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "-24.8947940001852"
+                "notionalPrincipal": -3376.11145407667,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": -24.8947940001852
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "IP",
-                "payoff": "-24.8947940001852",
+                "payoff": -24.8947940001852,
                 "currency": "USD",
-                "notionalPrincipal": "-3376.11145407667",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -3376.11145407667,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "PR",
-                "payoff": "-411.927535471469",
+                "payoff": -411.927535471469,
                 "currency": "USD",
-                "notionalPrincipal": "-2964.1839186052",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "-22.9390586468771"
+                "notionalPrincipal": -2964.1839186052,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": -22.9390586468771
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "IP",
-                "payoff": "-22.9390586468771",
+                "payoff": -22.9390586468771,
                 "currency": "USD",
-                "notionalPrincipal": "-2964.1839186052",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -2964.1839186052,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "PR",
-                "payoff": "-415.376069722038",
+                "payoff": -415.376069722038,
                 "currency": "USD",
-                "notionalPrincipal": "-2548.80784888316",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "-19.4905243963082"
+                "notionalPrincipal": -2548.80784888316,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": -19.4905243963082
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "IP",
-                "payoff": "-19.4905243963082",
+                "payoff": -19.4905243963082,
                 "currency": "USD",
-                "notionalPrincipal": "-2548.80784888316",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -2548.80784888316,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "PR",
-                "payoff": "-417.548666816345",
+                "payoff": -417.548666816345,
                 "currency": "USD",
-                "notionalPrincipal": "-2131.25918206682",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "-17.3179273020007"
+                "notionalPrincipal": -2131.25918206682,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": -17.3179273020007
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "IP",
-                "payoff": "-17.3179273020007",
+                "payoff": -17.3179273020007,
                 "currency": "USD",
-                "notionalPrincipal": "-2131.25918206682",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -2131.25918206682,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "PR",
-                "payoff": "-420.385709812796",
+                "payoff": -420.385709812796,
                 "currency": "USD",
-                "notionalPrincipal": "-1710.87347225402",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "-14.4808843055499"
+                "notionalPrincipal": -1710.87347225402,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": -14.4808843055499
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "IP",
-                "payoff": "-14.4808843055499",
+                "payoff": -14.4808843055499,
                 "currency": "USD",
-                "notionalPrincipal": "-1710.87347225402",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -1710.87347225402,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "PR",
-                "payoff": "-423.617015122703",
+                "payoff": -423.617015122703,
                 "currency": "USD",
-                "notionalPrincipal": "-1287.25645713132",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "-11.2495789956429"
+                "notionalPrincipal": -1287.25645713132,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": -11.2495789956429
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "IP",
-                "payoff": "-11.2495789956429",
+                "payoff": -11.2495789956429,
                 "currency": "USD",
-                "notionalPrincipal": "-1287.25645713132",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -1287.25645713132,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "PR",
-                "payoff": "-426.120303669892",
+                "payoff": -426.120303669892,
                 "currency": "USD",
-                "notionalPrincipal": "-861.136153461425",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "-8.74629044845388"
+                "notionalPrincipal": -861.136153461425,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": -8.74629044845388
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "IP",
-                "payoff": "-8.74629044845388",
+                "payoff": -8.74629044845388,
                 "currency": "USD",
-                "notionalPrincipal": "-861.136153461425",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -861.136153461425,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-12-01T00:00",
                 "eventType": "PR",
-                "payoff": "-429.204328999696",
+                "payoff": -429.204328999696,
                 "currency": "USD",
-                "notionalPrincipal": "-431.931824461729",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "-5.66226511865046"
+                "notionalPrincipal": -431.931824461729,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": -5.66226511865046
             },
             {
                 "eventDate": "2013-12-01T00:00",
                 "eventType": "IP",
-                "payoff": "-5.66226511865046",
+                "payoff": -5.66226511865046,
                 "currency": "USD",
-                "notionalPrincipal": "-431.931824461729",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -431.931824461729,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-01-01T00:00",
                 "eventType": "IP",
-                "payoff": "-2.93476965661668",
+                "payoff": -2.93476965661668,
                 "currency": "USD",
-                "notionalPrincipal": "-431.931824461729",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -431.931824461729,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-01-01T00:00",
                 "eventType": "MD",
-                "payoff": "-431.931824461729",
+                "payoff": -431.931824461729,
                 "currency": "USD",
-                "notionalPrincipal": "0.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0"
+                "notionalPrincipal": 0.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0
             }
         ]
     },
@@ -7631,164 +7631,164 @@
             {
                 "eventDate": "2013-01-01T00:00",
                 "eventType": "IED",
-                "payoff": "5000.0",
+                "payoff": 5000.0,
                 "currency": "USD",
-                "notionalPrincipal": "-5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "IPCI",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "-5198.35616438356",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -5198.35616438356,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "IP",
-                "payoff": "-70.6406755488835",
+                "payoff": -70.6406755488835,
                 "currency": "USD",
-                "notionalPrincipal": "-5198.35616438356",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -5198.35616438356,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-09-30T00:00",
                 "eventType": "PRF",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "-5198.35616438356",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "-33.0416063052"
+                "notionalPrincipal": -5198.35616438356,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": -33.0416063052
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "PR",
-                "payoff": "-728.337163175356",
+                "payoff": -728.337163175356,
                 "currency": "USD",
-                "notionalPrincipal": "-4470.01900120821",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "-34.1809720397823"
+                "notionalPrincipal": -4470.01900120821,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": -34.1809720397823
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "IP",
-                "payoff": "-34.1809720397823",
+                "payoff": -34.1809720397823,
                 "currency": "USD",
-                "notionalPrincipal": "-4470.01900120821",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -4470.01900120821,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "PR",
-                "payoff": "-732.146499261723",
+                "payoff": -732.146499261723,
                 "currency": "USD",
-                "notionalPrincipal": "-3737.87250194648",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "-30.3716359534147"
+                "notionalPrincipal": -3737.87250194648,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": -30.3716359534147
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "IP",
-                "payoff": "-30.3716359534147",
+                "payoff": -30.3716359534147,
                 "currency": "USD",
-                "notionalPrincipal": "-3737.87250194648",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -3737.87250194648,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-12-01T00:00",
                 "eventType": "PR",
-                "payoff": "-737.940343421517",
+                "payoff": -737.940343421517,
                 "currency": "USD",
-                "notionalPrincipal": "-2999.93215852496",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "-24.5777917936207"
+                "notionalPrincipal": -2999.93215852496,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": -24.5777917936207
             },
             {
                 "eventDate": "2013-12-01T00:00",
                 "eventType": "IP",
-                "payoff": "-24.5777917936207",
+                "payoff": -24.5777917936207,
                 "currency": "USD",
-                "notionalPrincipal": "-2999.93215852496",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -2999.93215852496,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-01-01T00:00",
                 "eventType": "PR",
-                "payoff": "-742.135034521599",
+                "payoff": -742.135034521599,
                 "currency": "USD",
-                "notionalPrincipal": "-2257.79712400337",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "-20.3831006935395"
+                "notionalPrincipal": -2257.79712400337,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": -20.3831006935395
             },
             {
                 "eventDate": "2014-01-01T00:00",
                 "eventType": "IP",
-                "payoff": "-20.3831006935395",
+                "payoff": -20.3831006935395,
                 "currency": "USD",
-                "notionalPrincipal": "-2257.79712400337",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -2257.79712400337,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-02-01T00:00",
                 "eventType": "PR",
-                "payoff": "-747.177486263006",
+                "payoff": -747.177486263006,
                 "currency": "USD",
-                "notionalPrincipal": "-1510.61963774036",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "-15.3406489521325"
+                "notionalPrincipal": -1510.61963774036,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": -15.3406489521325
             },
             {
                 "eventDate": "2014-02-01T00:00",
                 "eventType": "IP",
-                "payoff": "-15.3406489521325",
+                "payoff": -15.3406489521325,
                 "currency": "USD",
-                "notionalPrincipal": "-1510.61963774036",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -1510.61963774036,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-03-01T00:00",
                 "eventType": "PR",
-                "payoff": "-753.247483191745",
+                "payoff": -753.247483191745,
                 "currency": "USD",
-                "notionalPrincipal": "-757.372154548616",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "-9.2706520233929"
+                "notionalPrincipal": -757.372154548616,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": -9.2706520233929
             },
             {
                 "eventDate": "2014-03-01T00:00",
                 "eventType": "IP",
-                "payoff": "-9.2706520233929",
+                "payoff": -9.2706520233929,
                 "currency": "USD",
-                "notionalPrincipal": "-757.372154548616",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -757.372154548616,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-04-01T00:00",
                 "eventType": "IP",
-                "payoff": "-5.1459806665221",
+                "payoff": -5.1459806665221,
                 "currency": "USD",
-                "notionalPrincipal": "-757.372154548616",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -757.372154548616,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-04-01T00:00",
                 "eventType": "MD",
-                "payoff": "-757.372154548616",
+                "payoff": -757.372154548616,
                 "currency": "USD",
-                "notionalPrincipal": "0.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0"
+                "notionalPrincipal": 0.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0
             }
         ]
     },
@@ -7823,236 +7823,236 @@
             {
                 "eventDate": "2013-01-01T00:00",
                 "eventType": "IED",
-                "payoff": "-5000.0",
+                "payoff": -5000.0,
                 "currency": "USD",
-                "notionalPrincipal": "5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-01-31T00:00",
                 "eventType": "PRF",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "32.8767123287"
+                "notionalPrincipal": 5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 32.8767123287
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "PR",
-                "payoff": "433.042146153468",
+                "payoff": 433.042146153468,
                 "currency": "USD",
-                "notionalPrincipal": "4566.95785384653",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "33.972602739726"
+                "notionalPrincipal": 4566.95785384653,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 33.972602739726
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "IP",
-                "payoff": "33.972602739726",
+                "payoff": 33.972602739726,
                 "currency": "USD",
-                "notionalPrincipal": "4566.95785384653",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4566.95785384653,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "PR",
-                "payoff": "377.927790209941",
+                "payoff": 377.927790209941,
                 "currency": "USD",
-                "notionalPrincipal": "4189.03006363659",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "89.0869586832529"
+                "notionalPrincipal": 4189.03006363659,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 89.0869586832529
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "IP",
-                "payoff": "89.0869586832529",
+                "payoff": 89.0869586832529,
                 "currency": "USD",
-                "notionalPrincipal": "4189.03006363659",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4189.03006363659,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "PR",
-                "payoff": "382.545539938769",
+                "payoff": 382.545539938769,
                 "currency": "USD",
-                "notionalPrincipal": "3806.48452369782",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "84.4692089544255"
+                "notionalPrincipal": 3806.48452369782,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 84.4692089544255
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "IP",
-                "payoff": "84.4692089544255",
+                "payoff": 84.4692089544255,
                 "currency": "USD",
-                "notionalPrincipal": "3806.48452369782",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3806.48452369782,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "PR",
-                "payoff": "390.25933493589",
+                "payoff": 390.25933493589,
                 "currency": "USD",
-                "notionalPrincipal": "3416.22518876193",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "76.7554139573041"
+                "notionalPrincipal": 3416.22518876193,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 76.7554139573041
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "IP",
-                "payoff": "76.7554139573041",
+                "payoff": 76.7554139573041,
                 "currency": "USD",
-                "notionalPrincipal": "3416.22518876193",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3416.22518876193,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-02-01T00:00",
                 "eventType": "PR",
-                "payoff": "398.12867385405",
+                "payoff": 398.12867385405,
                 "currency": "USD",
-                "notionalPrincipal": "3018.09651490788",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "68.8860750391447"
+                "notionalPrincipal": 3018.09651490788,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 68.8860750391447
             },
             {
                 "eventDate": "2014-02-01T00:00",
                 "eventType": "IP",
-                "payoff": "68.8860750391447",
+                "payoff": 68.8860750391447,
                 "currency": "USD",
-                "notionalPrincipal": "3018.09651490788",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3018.09651490788,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-05-01T00:00",
                 "eventType": "PR",
-                "payoff": "408.141194958553",
+                "payoff": 408.141194958553,
                 "currency": "USD",
-                "notionalPrincipal": "2609.95531994933",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "58.8735539346414"
+                "notionalPrincipal": 2609.95531994933,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 58.8735539346414
             },
             {
                 "eventDate": "2014-05-01T00:00",
                 "eventType": "IP",
-                "payoff": "58.8735539346414",
+                "payoff": 58.8735539346414,
                 "currency": "USD",
-                "notionalPrincipal": "2609.95531994933",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2609.95531994933,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-08-01T00:00",
                 "eventType": "PR",
-                "payoff": "414.386608742983",
+                "payoff": 414.386608742983,
                 "currency": "USD",
-                "notionalPrincipal": "2195.56871120635",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "52.6281401502111"
+                "notionalPrincipal": 2195.56871120635,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 52.6281401502111
             },
             {
                 "eventDate": "2014-08-01T00:00",
                 "eventType": "IP",
-                "payoff": "52.6281401502111",
+                "payoff": 52.6281401502111,
                 "currency": "USD",
-                "notionalPrincipal": "2195.56871120635",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2195.56871120635,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-11-01T00:00",
                 "eventType": "PR",
-                "payoff": "422.742459264486",
+                "payoff": 422.742459264486,
                 "currency": "USD",
-                "notionalPrincipal": "1772.82625194186",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "44.2722896287088"
+                "notionalPrincipal": 1772.82625194186,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 44.2722896287088
             },
             {
                 "eventDate": "2014-11-01T00:00",
                 "eventType": "IP",
-                "payoff": "44.2722896287088",
+                "payoff": 44.2722896287088,
                 "currency": "USD",
-                "notionalPrincipal": "1772.82625194186",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1772.82625194186,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2015-02-01T00:00",
                 "eventType": "PR",
-                "payoff": "431.266800360887",
+                "payoff": 431.266800360887,
                 "currency": "USD",
-                "notionalPrincipal": "1341.55945158097",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "35.7479485323071"
+                "notionalPrincipal": 1341.55945158097,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 35.7479485323071
             },
             {
                 "eventDate": "2015-02-01T00:00",
                 "eventType": "IP",
-                "payoff": "35.7479485323071",
+                "payoff": 35.7479485323071,
                 "currency": "USD",
-                "notionalPrincipal": "1341.55945158097",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1341.55945158097,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2015-05-01T00:00",
                 "eventType": "PR",
-                "payoff": "440.845150823998",
+                "payoff": 440.845150823998,
                 "currency": "USD",
-                "notionalPrincipal": "900.714300756974",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "26.169598069196"
+                "notionalPrincipal": 900.714300756974,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 26.169598069196
             },
             {
                 "eventDate": "2015-05-01T00:00",
                 "eventType": "IP",
-                "payoff": "26.169598069196",
+                "payoff": 26.169598069196,
                 "currency": "USD",
-                "notionalPrincipal": "900.714300756974",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 900.714300756974,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2015-08-01T00:00",
                 "eventType": "PR",
-                "payoff": "448.852400253273",
+                "payoff": 448.852400253273,
                 "currency": "USD",
-                "notionalPrincipal": "451.861900503701",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "18.1623486399214"
+                "notionalPrincipal": 451.861900503701,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 18.1623486399214
             },
             {
                 "eventDate": "2015-08-01T00:00",
                 "eventType": "IP",
-                "payoff": "18.1623486399214",
+                "payoff": 18.1623486399214,
                 "currency": "USD",
-                "notionalPrincipal": "451.861900503701",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 451.861900503701,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2016-01-01T00:00",
                 "eventType": "IP",
-                "payoff": "15.152848389494",
+                "payoff": 15.152848389494,
                 "currency": "USD",
-                "notionalPrincipal": "451.8619005037",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 451.8619005037,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2016-01-01T00:00",
                 "eventType": "MD",
-                "payoff": "451.8619005037",
+                "payoff": 451.8619005037,
                 "currency": "USD",
-                "notionalPrincipal": "0.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0"
+                "notionalPrincipal": 0.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0
             }
         ]
     },
@@ -8088,236 +8088,236 @@
             {
                 "eventDate": "2013-01-01T00:00",
                 "eventType": "IP",
-                "payoff": "2.19178082191781",
+                "payoff": 2.19178082191781,
                 "currency": "USD",
-                "notionalPrincipal": "5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-01-31T00:00",
                 "eventType": "PRF",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "32.8767123287"
+                "notionalPrincipal": 5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 32.8767123287
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "PR",
-                "payoff": "400.89399137862",
+                "payoff": 400.89399137862,
                 "currency": "USD",
-                "notionalPrincipal": "4599.10600862138",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "33.972602739726"
+                "notionalPrincipal": 4599.10600862138,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 33.972602739726
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "IP",
-                "payoff": "33.972602739726",
+                "payoff": 33.972602739726,
                 "currency": "USD",
-                "notionalPrincipal": "4599.10600862138",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4599.10600862138,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "PR",
-                "payoff": "406.641943544889",
+                "payoff": 406.641943544889,
                 "currency": "USD",
-                "notionalPrincipal": "4192.46406507649",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "28.2246505734572"
+                "notionalPrincipal": 4192.46406507649,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 28.2246505734572
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "IP",
-                "payoff": "28.2246505734572",
+                "payoff": 28.2246505734572,
                 "currency": "USD",
-                "notionalPrincipal": "4192.46406507649",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4192.46406507649,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "PR",
-                "payoff": "406.380810881662",
+                "payoff": 406.380810881662,
                 "currency": "USD",
-                "notionalPrincipal": "3786.08325419483",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "28.4857832366841"
+                "notionalPrincipal": 3786.08325419483,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 28.4857832366841
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "IP",
-                "payoff": "28.4857832366841",
+                "payoff": 28.4857832366841,
                 "currency": "USD",
-                "notionalPrincipal": "3786.08325419483",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3786.08325419483,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "PR",
-                "payoff": "409.971800118161",
+                "payoff": 409.971800118161,
                 "currency": "USD",
-                "notionalPrincipal": "3376.11145407667",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "24.8947940001852"
+                "notionalPrincipal": 3376.11145407667,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 24.8947940001852
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "IP",
-                "payoff": "24.8947940001852",
+                "payoff": 24.8947940001852,
                 "currency": "USD",
-                "notionalPrincipal": "3376.11145407667",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3376.11145407667,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "PR",
-                "payoff": "411.927535471469",
+                "payoff": 411.927535471469,
                 "currency": "USD",
-                "notionalPrincipal": "2964.1839186051",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "22.9390586468771"
+                "notionalPrincipal": 2964.1839186051,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 22.9390586468771
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "IP",
-                "payoff": "22.9390586468771",
+                "payoff": 22.9390586468771,
                 "currency": "USD",
-                "notionalPrincipal": "2964.1839186051",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2964.1839186051,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "PR",
-                "payoff": "415.376069722038",
+                "payoff": 415.376069722038,
                 "currency": "USD",
-                "notionalPrincipal": "2548.80784888316",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "19.4905243963082"
+                "notionalPrincipal": 2548.80784888316,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 19.4905243963082
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "IP",
-                "payoff": "19.4905243963082",
+                "payoff": 19.4905243963082,
                 "currency": "USD",
-                "notionalPrincipal": "2548.80784888316",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2548.80784888316,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "PR",
-                "payoff": "417.548666816345",
+                "payoff": 417.548666816345,
                 "currency": "USD",
-                "notionalPrincipal": "2131.25918206682",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "17.3179273020007"
+                "notionalPrincipal": 2131.25918206682,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 17.3179273020007
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "IP",
-                "payoff": "17.3179273020007",
+                "payoff": 17.3179273020007,
                 "currency": "USD",
-                "notionalPrincipal": "2131.25918206682",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2131.25918206682,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "PR",
-                "payoff": "420.385709812796",
+                "payoff": 420.385709812796,
                 "currency": "USD",
-                "notionalPrincipal": "1710.87347225402",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "14.4808843055499"
+                "notionalPrincipal": 1710.87347225402,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 14.4808843055499
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "IP",
-                "payoff": "14.4808843055499",
+                "payoff": 14.4808843055499,
                 "currency": "USD",
-                "notionalPrincipal": "1710.87347225402",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1710.87347225402,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "PR",
-                "payoff": "423.617015122703",
+                "payoff": 423.617015122703,
                 "currency": "USD",
-                "notionalPrincipal": "1287.25645713132",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "11.2495789956429"
+                "notionalPrincipal": 1287.25645713132,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 11.2495789956429
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "IP",
-                "payoff": "11.2495789956429",
+                "payoff": 11.2495789956429,
                 "currency": "USD",
-                "notionalPrincipal": "1287.25645713132",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1287.25645713132,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "PR",
-                "payoff": "426.120303669892",
+                "payoff": 426.120303669892,
                 "currency": "USD",
-                "notionalPrincipal": "861.136153461425",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "8.74629044845388"
+                "notionalPrincipal": 861.136153461425,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 8.74629044845388
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "IP",
-                "payoff": "8.74629044845388",
+                "payoff": 8.74629044845388,
                 "currency": "USD",
-                "notionalPrincipal": "861.136153461425",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 861.136153461425,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-12-01T00:00",
                 "eventType": "PR",
-                "payoff": "429.204328999696",
+                "payoff": 429.204328999696,
                 "currency": "USD",
-                "notionalPrincipal": "431.931824461729",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "5.66226511865046"
+                "notionalPrincipal": 431.931824461729,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 5.66226511865046
             },
             {
                 "eventDate": "2013-12-01T00:00",
                 "eventType": "IP",
-                "payoff": "5.66226511865046",
+                "payoff": 5.66226511865046,
                 "currency": "USD",
-                "notionalPrincipal": "431.931824461729",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 431.931824461729,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-01-01T00:00",
                 "eventType": "IP",
-                "payoff": "2.93476965661668",
+                "payoff": 2.93476965661668,
                 "currency": "USD",
-                "notionalPrincipal": "431.931824461729",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 431.931824461729,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-01-01T00:00",
                 "eventType": "MD",
-                "payoff": "431.931824461729",
+                "payoff": 431.931824461729,
                 "currency": "USD",
-                "notionalPrincipal": "0.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0"
+                "notionalPrincipal": 0.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0
             }
         ]
     },
@@ -8372,281 +8372,281 @@
             {
                 "eventDate": "2013-01-01T00:00",
                 "eventType": "IED",
-                "payoff": "-5000.0",
+                "payoff": -5000.0,
                 "currency": "USD",
-                "notionalPrincipal": "5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "IP",
-                "payoff": "33.972602739726",
+                "payoff": 33.972602739726,
                 "currency": "USD",
-                "notionalPrincipal": "5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-02-28T00:00",
                 "eventType": "PRF",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "29.5890410958"
+                "notionalPrincipal": 5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 29.5890410958
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "PR",
-                "payoff": "442.088030567905",
+                "payoff": 442.088030567905,
                 "currency": "USD",
-                "notionalPrincipal": "4557.911969432",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "30.6849315068493"
+                "notionalPrincipal": 4557.911969432,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 30.6849315068493
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "IP",
-                "payoff": "30.6849315068493",
+                "payoff": 30.6849315068493,
                 "currency": "USD",
-                "notionalPrincipal": "4557.911969432",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4557.911969432,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "PR",
-                "payoff": "441.804135542722",
+                "payoff": 441.804135542722,
                 "currency": "USD",
-                "notionalPrincipal": "4116.10783388937",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "30.9688265320318"
+                "notionalPrincipal": 4116.10783388937,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 30.9688265320318
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "IP",
-                "payoff": "30.9688265320318",
+                "payoff": 30.9688265320318,
                 "currency": "USD",
-                "notionalPrincipal": "4116.10783388937",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4116.10783388937,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "RR",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "4116.10783388937",
-                "nominalInterestRate": "0.116679012345679",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4116.10783388937,
+                "nominalInterestRate": 0.116679012345679,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "PRF",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "4116.10783388937",
-                "nominalInterestRate": "0.11667901234567901",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4116.10783388937,
+                "nominalInterestRate": 0.11667901234567901,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "PR",
-                "payoff": "440.462761614414",
+                "payoff": 440.462761614414,
                 "currency": "USD",
-                "notionalPrincipal": "3675.64507227496",
-                "nominalInterestRate": "0.116679012345679",
-                "accruedInterest": "39.4737038438239"
+                "notionalPrincipal": 3675.64507227496,
+                "nominalInterestRate": 0.116679012345679,
+                "accruedInterest": 39.4737038438239
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "IP",
-                "payoff": "39.4737038438239",
+                "payoff": 39.4737038438239,
                 "currency": "USD",
-                "notionalPrincipal": "3675.64507227496",
-                "nominalInterestRate": "0.116679012345679",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3675.64507227496,
+                "nominalInterestRate": 0.116679012345679,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "PR",
-                "payoff": "443.51183603425",
+                "payoff": 443.51183603425,
                 "currency": "USD",
-                "notionalPrincipal": "3232.13323624071",
-                "nominalInterestRate": "0.116679012345679",
-                "accruedInterest": "36.4246294239875"
+                "notionalPrincipal": 3232.13323624071,
+                "nominalInterestRate": 0.116679012345679,
+                "accruedInterest": 36.4246294239875
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "IP",
-                "payoff": "36.4246294239875",
+                "payoff": 36.4246294239875,
                 "currency": "USD",
-                "notionalPrincipal": "3232.13323624071",
-                "nominalInterestRate": "0.116679012345679",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3232.13323624071,
+                "nominalInterestRate": 0.116679012345679,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "PR",
-                "payoff": "448.94012733981",
+                "payoff": 448.94012733981,
                 "currency": "USD",
-                "notionalPrincipal": "2783.1931089008",
-                "nominalInterestRate": "0.116679012345679",
-                "accruedInterest": "30.9963381184281"
+                "notionalPrincipal": 2783.1931089008,
+                "nominalInterestRate": 0.116679012345679,
+                "accruedInterest": 30.9963381184281
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "IP",
-                "payoff": "30.9963381184281",
+                "payoff": 30.9963381184281,
                 "currency": "USD",
-                "notionalPrincipal": "2783.1931089008",
-                "nominalInterestRate": "0.116679012345679",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2783.1931089008,
+                "nominalInterestRate": 0.116679012345679,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "RR",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "2783.1931089008",
-                "nominalInterestRate": "0.11779012345679",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2783.1931089008,
+                "nominalInterestRate": 0.11779012345679,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "PRF",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "2783.1931089008",
-                "nominalInterestRate": "0.11779012345679",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2783.1931089008,
+                "nominalInterestRate": 0.11779012345679,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "PR",
-                "payoff": "452.247432544185",
+                "payoff": 452.247432544185,
                 "currency": "USD",
-                "notionalPrincipal": "2330.94567635671",
-                "nominalInterestRate": "0.11779012345679",
-                "accruedInterest": "27.8433217998555"
+                "notionalPrincipal": 2330.94567635671,
+                "nominalInterestRate": 0.11779012345679,
+                "accruedInterest": 27.8433217998555
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "IP",
-                "payoff": "27.8433217998555",
+                "payoff": 27.8433217998555,
                 "currency": "USD",
-                "notionalPrincipal": "2330.94567635671",
-                "nominalInterestRate": "0.11779012345679",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2330.94567635671,
+                "nominalInterestRate": 0.11779012345679,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "PR",
-                "payoff": "456.771757772361",
+                "payoff": 456.771757772361,
                 "currency": "USD",
-                "notionalPrincipal": "1874.17391858435",
-                "nominalInterestRate": "0.11779012345679",
-                "accruedInterest": "23.3189965716794"
+                "notionalPrincipal": 1874.17391858435,
+                "nominalInterestRate": 0.11779012345679,
+                "accruedInterest": 23.3189965716794
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "IP",
-                "payoff": "23.3189965716794",
+                "payoff": 23.3189965716794,
                 "currency": "USD",
-                "notionalPrincipal": "1874.17391858435",
-                "nominalInterestRate": "0.11779012345679",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1874.17391858435,
+                "nominalInterestRate": 0.11779012345679,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "PR",
-                "payoff": "461.946164433119",
+                "payoff": 461.946164433119,
                 "currency": "USD",
-                "notionalPrincipal": "1412.22775415123",
-                "nominalInterestRate": "0.11779012345679",
-                "accruedInterest": "18.1445899109217"
+                "notionalPrincipal": 1412.22775415123,
+                "nominalInterestRate": 0.11779012345679,
+                "accruedInterest": 18.1445899109217
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "IP",
-                "payoff": "18.1445899109217",
+                "payoff": 18.1445899109217,
                 "currency": "USD",
-                "notionalPrincipal": "1412.22775415123",
-                "nominalInterestRate": "0.11779012345679",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1412.22775415123,
+                "nominalInterestRate": 0.11779012345679,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "RR",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "1412.22775415123",
-                "nominalInterestRate": "0.118901234567901",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1412.22775415123,
+                "nominalInterestRate": 0.118901234567901,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "PRF",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "1412.22775415123",
-                "nominalInterestRate": "0.118901234567901",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1412.22775415123,
+                "nominalInterestRate": 0.118901234567901,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "PR",
-                "payoff": "465.917899735783",
+                "payoff": 465.917899735783,
                 "currency": "USD",
-                "notionalPrincipal": "946.309854415451",
-                "nominalInterestRate": "0.118901234567901",
-                "accruedInterest": "14.2613269239691"
+                "notionalPrincipal": 946.309854415451,
+                "nominalInterestRate": 0.118901234567901,
+                "accruedInterest": 14.2613269239691
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "IP",
-                "payoff": "14.2613269239691",
+                "payoff": 14.2613269239691,
                 "currency": "USD",
-                "notionalPrincipal": "946.309854415451",
-                "nominalInterestRate": "0.118901234567901",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 946.309854415451,
+                "nominalInterestRate": 0.118901234567901,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-12-01T00:00",
                 "eventType": "PR",
-                "payoff": "470.931220360538",
+                "payoff": 470.931220360538,
                 "currency": "USD",
-                "notionalPrincipal": "475.378634054913",
-                "nominalInterestRate": "0.118901234567901",
-                "accruedInterest": "9.2480062992138"
+                "notionalPrincipal": 475.378634054913,
+                "nominalInterestRate": 0.118901234567901,
+                "accruedInterest": 9.2480062992138
             },
             {
                 "eventDate": "2013-12-01T00:00",
                 "eventType": "IP",
-                "payoff": "9.2480062992138",
+                "payoff": 9.2480062992138,
                 "currency": "USD",
-                "notionalPrincipal": "475.378634054913",
-                "nominalInterestRate": "0.118901234567901",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 475.378634054913,
+                "nominalInterestRate": 0.118901234567901,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-01-01T00:00",
                 "eventType": "IP",
-                "payoff": "4.80059260483912",
+                "payoff": 4.80059260483912,
                 "currency": "USD",
-                "notionalPrincipal": "475.378634054913",
-                "nominalInterestRate": "0.118901234567901",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 475.378634054913,
+                "nominalInterestRate": 0.118901234567901,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-01-01T00:00",
                 "eventType": "MD",
-                "payoff": "475.378634054913",
+                "payoff": 475.378634054913,
                 "currency": "USD",
-                "notionalPrincipal": "0.0",
-                "nominalInterestRate": "0.118901234567901",
-                "accruedInterest": "0"
+                "notionalPrincipal": 0.0,
+                "nominalInterestRate": 0.118901234567901,
+                "accruedInterest": 0
             }
         ]
     },
@@ -8701,281 +8701,281 @@
             {
                 "eventDate": "2013-01-01T00:00",
                 "eventType": "IED",
-                "payoff": "-5000.0",
+                "payoff": -5000.0,
                 "currency": "USD",
-                "notionalPrincipal": "5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "IP",
-                "payoff": "33.972602739726",
+                "payoff": 33.972602739726,
                 "currency": "USD",
-                "notionalPrincipal": "5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-02-28T00:00",
                 "eventType": "PRF",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "29.5890410958"
+                "notionalPrincipal": 5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 29.5890410958
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "PR",
-                "payoff": "442.088030567905",
+                "payoff": 442.088030567905,
                 "currency": "USD",
-                "notionalPrincipal": "4557.911969432",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "30.6849315068493"
+                "notionalPrincipal": 4557.911969432,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 30.6849315068493
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "IP",
-                "payoff": "30.6849315068493",
+                "payoff": 30.6849315068493,
                 "currency": "USD",
-                "notionalPrincipal": "4557.911969432",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4557.911969432,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "PR",
-                "payoff": "441.804135542722",
+                "payoff": 441.804135542722,
                 "currency": "USD",
-                "notionalPrincipal": "4116.10783388937",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "30.9688265320318"
+                "notionalPrincipal": 4116.10783388937,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 30.9688265320318
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "IP",
-                "payoff": "30.9688265320318",
+                "payoff": 30.9688265320318,
                 "currency": "USD",
-                "notionalPrincipal": "4116.10783388937",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4116.10783388937,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "RR",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "4116.10783388937",
-                "nominalInterestRate": "0.115851851848522",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4116.10783388937,
+                "nominalInterestRate": 0.115851851848522,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "PRF",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "4116.10783388937",
-                "nominalInterestRate": "0.115851851848522",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4116.10783388937,
+                "nominalInterestRate": 0.115851851848522,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "PR",
-                "payoff": "440.580430783375",
+                "payoff": 440.580430783375,
                 "currency": "USD",
-                "notionalPrincipal": "3675.5274031059",
-                "nominalInterestRate": "0.115851851848522",
-                "accruedInterest": "39.1938669833666"
+                "notionalPrincipal": 3675.5274031059,
+                "nominalInterestRate": 0.115851851848522,
+                "accruedInterest": 39.1938669833666
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "IP",
-                "payoff": "39.1938669833666",
+                "payoff": 39.1938669833666,
                 "currency": "USD",
-                "notionalPrincipal": "3675.5274031059",
-                "nominalInterestRate": "0.115851851848522",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3675.5274031059,
+                "nominalInterestRate": 0.115851851848522,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "PR",
-                "payoff": "443.609047516702",
+                "payoff": 443.609047516702,
                 "currency": "USD",
-                "notionalPrincipal": "3231.9183555892",
-                "nominalInterestRate": "0.115851851848522",
-                "accruedInterest": "36.1652502500395"
+                "notionalPrincipal": 3231.9183555892,
+                "nominalInterestRate": 0.115851851848522,
+                "accruedInterest": 36.1652502500395
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "IP",
-                "payoff": "36.1652502500395",
+                "payoff": 36.1652502500395,
                 "currency": "USD",
-                "notionalPrincipal": "3231.9183555892",
-                "nominalInterestRate": "0.115851851848522",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3231.9183555892,
+                "nominalInterestRate": 0.115851851848522,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "PR",
-                "payoff": "448.999744902228",
+                "payoff": 448.999744902228,
                 "currency": "USD",
-                "notionalPrincipal": "2782.91861068707",
-                "nominalInterestRate": "0.115851851848522",
-                "accruedInterest": "30.7745528645138"
+                "notionalPrincipal": 2782.91861068707,
+                "nominalInterestRate": 0.115851851848522,
+                "accruedInterest": 30.7745528645138
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "IP",
-                "payoff": "30.7745528645138",
+                "payoff": 30.7745528645138,
                 "currency": "USD",
-                "notionalPrincipal": "2782.91861068707",
-                "nominalInterestRate": "0.115851851848522",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2782.91861068707,
+                "nominalInterestRate": 0.115851851848522,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "RR",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "2782.91861068707",
-                "nominalInterestRate": "0.117518518518519",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2782.91861068707,
+                "nominalInterestRate": 0.117518518518519,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "PRF",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "2782.91861068707",
-                "nominalInterestRate": "0.117518518518519",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2782.91861068707,
+                "nominalInterestRate": 0.117518518518519,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "PR",
-                "payoff": "452.229311050778",
+                "payoff": 452.229311050778,
                 "currency": "USD",
-                "notionalPrincipal": "2330.68929963629",
-                "nominalInterestRate": "0.117518518518519",
-                "accruedInterest": "27.7763798379515"
+                "notionalPrincipal": 2330.68929963629,
+                "nominalInterestRate": 0.117518518518519,
+                "accruedInterest": 27.7763798379515
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "IP",
-                "payoff": "27.7763798379515",
+                "payoff": 27.7763798379515,
                 "currency": "USD",
-                "notionalPrincipal": "2330.68929963629",
-                "nominalInterestRate": "0.117518518518519",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2330.68929963629,
+                "nominalInterestRate": 0.117518518518519,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "PR",
-                "payoff": "456.743023047012",
+                "payoff": 456.743023047012,
                 "currency": "USD",
-                "notionalPrincipal": "1873.94627658928",
-                "nominalInterestRate": "0.117518518518519",
-                "accruedInterest": "23.2626678417173"
+                "notionalPrincipal": 1873.94627658928,
+                "nominalInterestRate": 0.117518518518519,
+                "accruedInterest": 23.2626678417173
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "IP",
-                "payoff": "23.2626678417173",
+                "payoff": 23.2626678417173,
                 "currency": "USD",
-                "notionalPrincipal": "1873.94627658928",
-                "nominalInterestRate": "0.117518518518519",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1873.94627658928,
+                "nominalInterestRate": 0.117518518518519,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "PR",
-                "payoff": "461.905138268888",
+                "payoff": 461.905138268888,
                 "currency": "USD",
-                "notionalPrincipal": "1412.04113832039",
-                "nominalInterestRate": "0.117518518518519",
-                "accruedInterest": "18.100552619841"
+                "notionalPrincipal": 1412.04113832039,
+                "nominalInterestRate": 0.117518518518519,
+                "accruedInterest": 18.100552619841
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "IP",
-                "payoff": "18.100552619841",
+                "payoff": 18.100552619841,
                 "currency": "USD",
-                "notionalPrincipal": "1412.04113832039",
-                "nominalInterestRate": "0.117518518518519",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1412.04113832039,
+                "nominalInterestRate": 0.117518518518519,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "RR",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "1412.04113832039",
-                "nominalInterestRate": "0.119185185185185",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1412.04113832039,
+                "nominalInterestRate": 0.119185185185185,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "PRF",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "1412.04113832039",
-                "nominalInterestRate": "0.119185185185185",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1412.04113832039,
+                "nominalInterestRate": 0.119185185185185,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "PR",
-                "payoff": "465.844886195954",
+                "payoff": 465.844886195954,
                 "currency": "USD",
-                "notionalPrincipal": "946.196252124437",
-                "nominalInterestRate": "0.119185185185185",
-                "accruedInterest": "14.2934956749432"
+                "notionalPrincipal": 946.196252124437,
+                "nominalInterestRate": 0.119185185185185,
+                "accruedInterest": 14.2934956749432
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "IP",
-                "payoff": "14.2934956749432",
+                "payoff": 14.2934956749432,
                 "currency": "USD",
-                "notionalPrincipal": "946.196252124437",
-                "nominalInterestRate": "0.119185185185185",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 946.196252124437,
+                "nominalInterestRate": 0.119185185185185,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-12-01T00:00",
                 "eventType": "PR",
-                "payoff": "470.869403060132",
+                "payoff": 470.869403060132,
                 "currency": "USD",
-                "notionalPrincipal": "475.326849064306",
-                "nominalInterestRate": "0.119185185185185",
-                "accruedInterest": "9.26897881076542"
+                "notionalPrincipal": 475.326849064306,
+                "nominalInterestRate": 0.119185185185185,
+                "accruedInterest": 9.26897881076542
             },
             {
                 "eventDate": "2013-12-01T00:00",
                 "eventType": "IP",
-                "payoff": "9.26897881076542",
+                "payoff": 9.26897881076542,
                 "currency": "USD",
-                "notionalPrincipal": "475.326849064306",
-                "nominalInterestRate": "0.119185185185185",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 475.326849064306,
+                "nominalInterestRate": 0.119185185185185,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-01-01T00:00",
                 "eventType": "IP",
-                "payoff": "4.81153280659128",
+                "payoff": 4.81153280659128,
                 "currency": "USD",
-                "notionalPrincipal": "475.326849064306",
-                "nominalInterestRate": "0.119185185185185",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 475.326849064306,
+                "nominalInterestRate": 0.119185185185185,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-01-01T00:00",
                 "eventType": "MD",
-                "payoff": "475.326849064306",
+                "payoff": 475.326849064306,
                 "currency": "USD",
-                "notionalPrincipal": "0.0",
-                "nominalInterestRate": "0.119185185185185",
-                "accruedInterest": "0"
+                "notionalPrincipal": 0.0,
+                "nominalInterestRate": 0.119185185185185,
+                "accruedInterest": 0
             }
         ]
     },
@@ -9010,218 +9010,218 @@
             {
                 "eventDate": "2013-01-01T00:00",
                 "eventType": "IED",
-                "payoff": "-5000.0",
+                "payoff": -5000.0,
                 "currency": "USD",
-                "notionalPrincipal": "5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-01-31T00:00",
                 "eventType": "PRF",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "32.8767123287"
+                "notionalPrincipal": 5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 32.8767123287
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "PR",
-                "payoff": "439.145566925411",
+                "payoff": 439.145566925411,
                 "currency": "USD",
-                "notionalPrincipal": "4560.85443307459",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "33.972602739726"
+                "notionalPrincipal": 4560.85443307459,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 33.972602739726
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "IP",
-                "payoff": "33.972602739726",
+                "payoff": 33.972602739726,
                 "currency": "USD",
-                "notionalPrincipal": "4560.85443307459",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4560.85443307459,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "PR",
-                "payoff": "445.128268486816",
+                "payoff": 445.128268486816,
                 "currency": "USD",
-                "notionalPrincipal": "4115.72616458777",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "27.9899011783208"
+                "notionalPrincipal": 4115.72616458777,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 27.9899011783208
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "IP",
-                "payoff": "27.9899011783208",
+                "payoff": 27.9899011783208,
                 "currency": "USD",
-                "notionalPrincipal": "4115.72616458777",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4115.72616458777,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "PR",
-                "payoff": "445.153783670129",
+                "payoff": 445.153783670129,
                 "currency": "USD",
-                "notionalPrincipal": "3670.57238091764",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "27.9643859950073"
+                "notionalPrincipal": 3670.57238091764,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 27.9643859950073
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "IP",
-                "payoff": "27.9643859950073",
+                "payoff": 27.9643859950073,
                 "currency": "USD",
-                "notionalPrincipal": "3670.57238091764",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3670.57238091764,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "PR",
-                "payoff": "448.982899215267",
+                "payoff": 448.982899215267,
                 "currency": "USD",
-                "notionalPrincipal": "3221.58948170238",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "24.1352704498694"
+                "notionalPrincipal": 3221.58948170238,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 24.1352704498694
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "IP",
-                "payoff": "24.1352704498694",
+                "payoff": 24.1352704498694,
                 "currency": "USD",
-                "notionalPrincipal": "3221.58948170238",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3221.58948170238,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "PR",
-                "payoff": "451.229013734666",
+                "payoff": 451.229013734666,
                 "currency": "USD",
-                "notionalPrincipal": "2770.36046796771",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "21.8891559304709"
+                "notionalPrincipal": 2770.36046796771,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 21.8891559304709
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "IP",
-                "payoff": "21.8891559304709",
+                "payoff": 21.8891559304709,
                 "currency": "USD",
-                "notionalPrincipal": "2770.36046796771",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2770.36046796771,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "PR",
-                "payoff": "454.902100834664",
+                "payoff": 454.902100834664,
                 "currency": "USD",
-                "notionalPrincipal": "2315.45836713305",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "18.2160688304726"
+                "notionalPrincipal": 2315.45836713305,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 18.2160688304726
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "IP",
-                "payoff": "18.2160688304726",
+                "payoff": 18.2160688304726,
                 "currency": "USD",
-                "notionalPrincipal": "2315.45836713305",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2315.45836713305,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "PR",
-                "payoff": "457.38574021174",
+                "payoff": 457.38574021174,
                 "currency": "USD",
-                "notionalPrincipal": "1858.07262692131",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "15.7324294533971"
+                "notionalPrincipal": 1858.07262692131,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 15.7324294533971
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "IP",
-                "payoff": "15.7324294533971",
+                "payoff": 15.7324294533971,
                 "currency": "USD",
-                "notionalPrincipal": "1858.07262692131",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1858.07262692131,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "PR",
-                "payoff": "460.493457021945",
+                "payoff": 460.493457021945,
                 "currency": "USD",
-                "notionalPrincipal": "1397.57916989936",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "12.6247126431913"
+                "notionalPrincipal": 1397.57916989936,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 12.6247126431913
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "IP",
-                "payoff": "12.6247126431913",
+                "payoff": 12.6247126431913,
                 "currency": "USD",
-                "notionalPrincipal": "1397.57916989936",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1397.57916989936,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "PR",
-                "payoff": "463.928608000045",
+                "payoff": 463.928608000045,
                 "currency": "USD",
-                "notionalPrincipal": "933.650561899316",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "9.18956166509169"
+                "notionalPrincipal": 933.650561899316,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 9.18956166509169
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "IP",
-                "payoff": "9.18956166509169",
+                "payoff": 9.18956166509169,
                 "currency": "USD",
-                "notionalPrincipal": "933.650561899316",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 933.650561899316,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "PR",
-                "payoff": "466.774461737711",
+                "payoff": 466.774461737711,
                 "currency": "USD",
-                "notionalPrincipal": "466.876100161605",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "6.34370792742549"
+                "notionalPrincipal": 466.876100161605,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 6.34370792742549
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "IP",
-                "payoff": "6.34370792742549",
+                "payoff": 6.34370792742549,
                 "currency": "USD",
-                "notionalPrincipal": "466.876100161605",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 466.876100161605,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-12-31T23:59:59",
                 "eventType": "IP",
-                "payoff": "6.2420695035305",
+                "payoff": 6.2420695035305,
                 "currency": "USD",
-                "notionalPrincipal": "466.876100161605",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 466.876100161605,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-12-31T23:59:59",
                 "eventType": "MD",
-                "payoff": "466.876100161605",
+                "payoff": 466.876100161605,
                 "currency": "USD",
-                "notionalPrincipal": "0.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0"
+                "notionalPrincipal": 0.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0
             }
         ]
     },
@@ -9256,236 +9256,236 @@
             {
                 "eventDate": "2013-01-01T00:00",
                 "eventType": "IED",
-                "payoff": "-5000.0",
+                "payoff": -5000.0,
                 "currency": "USD",
-                "notionalPrincipal": "5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-01-31T00:00",
                 "eventType": "PRF",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "32.8767123287"
+                "notionalPrincipal": 5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 32.8767123287
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "PR",
-                "payoff": "400.89399137862",
+                "payoff": 400.89399137862,
                 "currency": "USD",
-                "notionalPrincipal": "4599.10600862138",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "33.972602739726"
+                "notionalPrincipal": 4599.10600862138,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 33.972602739726
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "IP",
-                "payoff": "33.972602739726",
+                "payoff": 33.972602739726,
                 "currency": "USD",
-                "notionalPrincipal": "4599.10600862138",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4599.10600862138,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "PR",
-                "payoff": "406.641943544889",
+                "payoff": 406.641943544889,
                 "currency": "USD",
-                "notionalPrincipal": "4192.46406507649",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "28.2246505734572"
+                "notionalPrincipal": 4192.46406507649,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 28.2246505734572
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "IP",
-                "payoff": "28.2246505734572",
+                "payoff": 28.2246505734572,
                 "currency": "USD",
-                "notionalPrincipal": "4192.46406507649",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4192.46406507649,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "PR",
-                "payoff": "406.380810881662",
+                "payoff": 406.380810881662,
                 "currency": "USD",
-                "notionalPrincipal": "3786.08325419483",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "28.4857832366841"
+                "notionalPrincipal": 3786.08325419483,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 28.4857832366841
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "IP",
-                "payoff": "28.4857832366841",
+                "payoff": 28.4857832366841,
                 "currency": "USD",
-                "notionalPrincipal": "3786.08325419483",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3786.08325419483,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "PR",
-                "payoff": "409.971800118161",
+                "payoff": 409.971800118161,
                 "currency": "USD",
-                "notionalPrincipal": "3376.11145407667",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "24.8947940001852"
+                "notionalPrincipal": 3376.11145407667,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 24.8947940001852
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "IP",
-                "payoff": "24.8947940001852",
+                "payoff": 24.8947940001852,
                 "currency": "USD",
-                "notionalPrincipal": "3376.11145407667",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3376.11145407667,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "PR",
-                "payoff": "411.927535471469",
+                "payoff": 411.927535471469,
                 "currency": "USD",
-                "notionalPrincipal": "2964.1839186052",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "22.9390586468771"
+                "notionalPrincipal": 2964.1839186052,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 22.9390586468771
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "IP",
-                "payoff": "22.9390586468771",
+                "payoff": 22.9390586468771,
                 "currency": "USD",
-                "notionalPrincipal": "2964.1839186052",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2964.1839186052,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "PR",
-                "payoff": "415.376069722038",
+                "payoff": 415.376069722038,
                 "currency": "USD",
-                "notionalPrincipal": "2548.80784888316",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "19.4905243963082"
+                "notionalPrincipal": 2548.80784888316,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 19.4905243963082
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "IP",
-                "payoff": "19.4905243963082",
+                "payoff": 19.4905243963082,
                 "currency": "USD",
-                "notionalPrincipal": "2548.80784888316",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2548.80784888316,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "PR",
-                "payoff": "417.548666816345",
+                "payoff": 417.548666816345,
                 "currency": "USD",
-                "notionalPrincipal": "2131.25918206682",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "17.3179273020007"
+                "notionalPrincipal": 2131.25918206682,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 17.3179273020007
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "IP",
-                "payoff": "17.3179273020007",
+                "payoff": 17.3179273020007,
                 "currency": "USD",
-                "notionalPrincipal": "2131.25918206682",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2131.25918206682,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "PR",
-                "payoff": "420.385709812796",
+                "payoff": 420.385709812796,
                 "currency": "USD",
-                "notionalPrincipal": "1710.87347225402",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "14.4808843055499"
+                "notionalPrincipal": 1710.87347225402,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 14.4808843055499
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "IP",
-                "payoff": "14.4808843055499",
+                "payoff": 14.4808843055499,
                 "currency": "USD",
-                "notionalPrincipal": "1710.87347225402",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1710.87347225402,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "PR",
-                "payoff": "423.617015122703",
+                "payoff": 423.617015122703,
                 "currency": "USD",
-                "notionalPrincipal": "1287.25645713132",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "11.2495789956429"
+                "notionalPrincipal": 1287.25645713132,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 11.2495789956429
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "IP",
-                "payoff": "11.2495789956429",
+                "payoff": 11.2495789956429,
                 "currency": "USD",
-                "notionalPrincipal": "1287.25645713132",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1287.25645713132,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "PR",
-                "payoff": "426.120303669892",
+                "payoff": 426.120303669892,
                 "currency": "USD",
-                "notionalPrincipal": "861.136153461425",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "8.74629044845388"
+                "notionalPrincipal": 861.136153461425,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 8.74629044845388
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "IP",
-                "payoff": "8.74629044845388",
+                "payoff": 8.74629044845388,
                 "currency": "USD",
-                "notionalPrincipal": "861.136153461425",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 861.136153461425,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-12-01T00:00",
                 "eventType": "PR",
-                "payoff": "429.204328999696",
+                "payoff": 429.204328999696,
                 "currency": "USD",
-                "notionalPrincipal": "431.931824461729",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "5.66226511865046"
+                "notionalPrincipal": 431.931824461729,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 5.66226511865046
             },
             {
                 "eventDate": "2013-12-01T00:00",
                 "eventType": "IP",
-                "payoff": "5.66226511865046",
+                "payoff": 5.66226511865046,
                 "currency": "USD",
-                "notionalPrincipal": "431.931824461729",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 431.931824461729,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-01-01T00:00",
                 "eventType": "IP",
-                "payoff": "2.93476965661668",
+                "payoff": 2.93476965661668,
                 "currency": "USD",
-                "notionalPrincipal": "431.931824461729",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 431.931824461729,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-01-01T00:00",
                 "eventType": "MD",
-                "payoff": "431.931824461729",
+                "payoff": 431.931824461729,
                 "currency": "USD",
-                "notionalPrincipal": "0.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0"
+                "notionalPrincipal": 0.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0
             }
         ]
     },
@@ -9523,155 +9523,155 @@
             {
                 "eventDate": "2013-01-01T00:00",
                 "eventType": "IED",
-                "payoff": "-5000.0",
+                "payoff": -5000.0,
                 "currency": "USD",
-                "notionalPrincipal": "5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "PR",
-                "payoff": "666.666666666667",
+                "payoff": 666.666666666667,
                 "currency": "USD",
-                "notionalPrincipal": "4333.33333333333",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "33.3333333333333"
+                "notionalPrincipal": 4333.33333333333,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 33.3333333333333
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "IP",
-                "payoff": "33.3333333333333",
+                "payoff": 33.3333333333333,
                 "currency": "USD",
-                "notionalPrincipal": "4333.33333333333",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4333.33333333333,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "PR",
-                "payoff": "671.111111111111",
+                "payoff": 671.111111111111,
                 "currency": "USD",
-                "notionalPrincipal": "3662.22222222222",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "28.8888888888889"
+                "notionalPrincipal": 3662.22222222222,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 28.8888888888889
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "IP",
-                "payoff": "28.8888888888889",
+                "payoff": 28.8888888888889,
                 "currency": "USD",
-                "notionalPrincipal": "3662.22222222222",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3662.22222222222,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "PR",
-                "payoff": "675.585185185185",
+                "payoff": 675.585185185185,
                 "currency": "USD",
-                "notionalPrincipal": "2986.63703703704",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "24.4148148148148"
+                "notionalPrincipal": 2986.63703703704,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 24.4148148148148
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "IP",
-                "payoff": "24.4148148148148",
+                "payoff": 24.4148148148148,
                 "currency": "USD",
-                "notionalPrincipal": "2986.63703703704",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2986.63703703704,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "PR",
-                "payoff": "680.089086419753",
+                "payoff": 680.089086419753,
                 "currency": "USD",
-                "notionalPrincipal": "2306.54795061728",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "19.9109135802469"
+                "notionalPrincipal": 2306.54795061728,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 19.9109135802469
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "IP",
-                "payoff": "19.9109135802469",
+                "payoff": 19.9109135802469,
                 "currency": "USD",
-                "notionalPrincipal": "2306.54795061728",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2306.54795061728,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-06-03T00:00",
                 "eventType": "PR",
-                "payoff": "683.597881240055",
+                "payoff": 683.597881240055,
                 "currency": "USD",
-                "notionalPrincipal": "1622.95006937723",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "16.4021187599451"
+                "notionalPrincipal": 1622.95006937723,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 16.4021187599451
             },
             {
                 "eventDate": "2013-06-03T00:00",
                 "eventType": "IP",
-                "payoff": "16.4021187599451",
+                "payoff": 16.4021187599451,
                 "currency": "USD",
-                "notionalPrincipal": "1622.95006937723",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1622.95006937723,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "PR",
-                "payoff": "689.901644012764",
+                "payoff": 689.901644012764,
                 "currency": "USD",
-                "notionalPrincipal": "933.048425364465",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "10.0983559872361"
+                "notionalPrincipal": 933.048425364465,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 10.0983559872361
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "IP",
-                "payoff": "10.0983559872361",
+                "payoff": 10.0983559872361,
                 "currency": "USD",
-                "notionalPrincipal": "933.048425364465",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 933.048425364465,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "PR",
-                "payoff": "693.779677164237",
+                "payoff": 693.779677164237,
                 "currency": "USD",
-                "notionalPrincipal": "239.268748200228",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "6.2203228357631"
+                "notionalPrincipal": 239.268748200228,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 6.2203228357631
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "IP",
-                "payoff": "6.2203228357631",
+                "payoff": 6.2203228357631,
                 "currency": "USD",
-                "notionalPrincipal": "239.268748200228",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 239.268748200228,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-09-02T00:00",
                 "eventType": "IP",
-                "payoff": "1.6482958209349",
+                "payoff": 1.6482958209349,
                 "currency": "USD",
-                "notionalPrincipal": "239.268748200228",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 239.268748200228,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-09-02T00:00",
                 "eventType": "MD",
-                "payoff": "239.268748200228",
+                "payoff": 239.268748200228,
                 "currency": "USD",
-                "notionalPrincipal": "0.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0"
+                "notionalPrincipal": 0.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0
             }
         ]
     },
@@ -9706,218 +9706,218 @@
             {
                 "eventDate": "2013-01-01T00:00",
                 "eventType": "IED",
-                "payoff": "-5000.0",
+                "payoff": -5000.0,
                 "currency": "USD",
-                "notionalPrincipal": "5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "IP",
-                "payoff": "33.972602739726",
+                "payoff": 33.972602739726,
                 "currency": "USD",
-                "notionalPrincipal": "5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "IP",
-                "payoff": "30.6849315068493",
+                "payoff": 30.6849315068493,
                 "currency": "USD",
-                "notionalPrincipal": "5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-03-31T00:00",
                 "eventType": "PRF",
-                "payoff": "0.0",
+                "payoff": 0.0,
                 "currency": "USD",
-                "notionalPrincipal": "5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "32.8767123287"
+                "notionalPrincipal": 5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 32.8767123287
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "PR",
-                "payoff": "484.656283958212",
+                "payoff": 484.656283958212,
                 "currency": "USD",
-                "notionalPrincipal": "4515.34371604179",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "33.972602739726"
+                "notionalPrincipal": 4515.34371604179,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 33.972602739726
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "IP",
-                "payoff": "33.972602739726",
+                "payoff": 33.972602739726,
                 "currency": "USD",
-                "notionalPrincipal": "4515.34371604179",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4515.34371604179,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "PR",
-                "payoff": "488.938955414375",
+                "payoff": 488.938955414375,
                 "currency": "USD",
-                "notionalPrincipal": "4026.40476062741",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "29.6899312835624"
+                "notionalPrincipal": 4026.40476062741,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 29.6899312835624
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "IP",
-                "payoff": "29.6899312835624",
+                "payoff": 29.6899312835624,
                 "currency": "USD",
-                "notionalPrincipal": "4026.40476062741",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 4026.40476062741,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "PR",
-                "payoff": "491.27139681751",
+                "payoff": 491.27139681751,
                 "currency": "USD",
-                "notionalPrincipal": "3535.1333638099",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "27.3574898804274"
+                "notionalPrincipal": 3535.1333638099,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 27.3574898804274
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "IP",
-                "payoff": "27.3574898804274",
+                "payoff": 27.3574898804274,
                 "currency": "USD",
-                "notionalPrincipal": "3535.1333638099",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3535.1333638099,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "PR",
-                "payoff": "495.384174168777",
+                "payoff": 495.384174168777,
                 "currency": "USD",
-                "notionalPrincipal": "3039.74918964113",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "23.244712529161"
+                "notionalPrincipal": 3039.74918964113,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 23.244712529161
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "IP",
-                "payoff": "23.244712529161",
+                "payoff": 23.244712529161,
                 "currency": "USD",
-                "notionalPrincipal": "3039.74918964113",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 3039.74918964113,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "PR",
-                "payoff": "497.975248368321",
+                "payoff": 497.975248368321,
                 "currency": "USD",
-                "notionalPrincipal": "2541.7739412728",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "20.6536383296164"
+                "notionalPrincipal": 2541.7739412728,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 20.6536383296164
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "IP",
-                "payoff": "20.6536383296164",
+                "payoff": 20.6536383296164,
                 "currency": "USD",
-                "notionalPrincipal": "2541.7739412728",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2541.7739412728,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "PR",
-                "payoff": "501.358751425728",
+                "payoff": 501.358751425728,
                 "currency": "USD",
-                "notionalPrincipal": "2040.41518984708",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "17.2701352722097"
+                "notionalPrincipal": 2040.41518984708,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 17.2701352722097
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "IP",
-                "payoff": "17.2701352722097",
+                "payoff": 17.2701352722097,
                 "currency": "USD",
-                "notionalPrincipal": "2040.41518984708",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 2040.41518984708,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "PR",
-                "payoff": "505.212458052368",
+                "payoff": 505.212458052368,
                 "currency": "USD",
-                "notionalPrincipal": "1535.20273179471",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "13.4164286455698"
+                "notionalPrincipal": 1535.20273179471,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 13.4164286455698
             },
             {
                 "eventDate": "2013-10-01T00:00",
                 "eventType": "IP",
-                "payoff": "13.4164286455698",
+                "payoff": 13.4164286455698,
                 "currency": "USD",
-                "notionalPrincipal": "1535.20273179471",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1535.20273179471,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "PR",
-                "payoff": "508.197920191497",
+                "payoff": 508.197920191497,
                 "currency": "USD",
-                "notionalPrincipal": "1027.00481160321",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "10.4309665064408"
+                "notionalPrincipal": 1027.00481160321,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 10.4309665064408
             },
             {
                 "eventDate": "2013-11-01T00:00",
                 "eventType": "IP",
-                "payoff": "10.4309665064408",
+                "payoff": 10.4309665064408,
                 "currency": "USD",
-                "notionalPrincipal": "1027.00481160321",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 1027.00481160321,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-12-01T00:00",
                 "eventType": "PR",
-                "payoff": "511.87597834767",
+                "payoff": 511.87597834767,
                 "currency": "USD",
-                "notionalPrincipal": "515.128833255542",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "6.75290835026769"
+                "notionalPrincipal": 515.128833255542,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 6.75290835026769
             },
             {
                 "eventDate": "2013-12-01T00:00",
                 "eventType": "IP",
-                "payoff": "6.75290835026769",
+                "payoff": 6.75290835026769,
                 "currency": "USD",
-                "notionalPrincipal": "515.128833255542",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 515.128833255542,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-01-01T00:00",
                 "eventType": "IP",
-                "payoff": "3.50005344239382",
+                "payoff": 3.50005344239382,
                 "currency": "USD",
-                "notionalPrincipal": "515.128833255542",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 515.128833255542,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2014-01-01T00:00",
                 "eventType": "MD",
-                "payoff": "515.128833255542",
+                "payoff": 515.128833255542,
                 "currency": "USD",
-                "notionalPrincipal": "0.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0"
+                "notionalPrincipal": 0.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0
             }
         ]
     },
@@ -9953,155 +9953,155 @@
             {
                 "eventDate": "2013-01-01T00:00",
                 "eventType": "IED",
-                "payoff": "5000.0",
+                "payoff": 5000.0,
                 "currency": "USD",
-                "notionalPrincipal": "-5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "PR",
-                "payoff": "-666.027397260274",
+                "payoff": -666.027397260274,
                 "currency": "USD",
-                "notionalPrincipal": "-4333.97260273973",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "-33.972602739726"
+                "notionalPrincipal": -4333.97260273973,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": -33.972602739726
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "IP",
-                "payoff": "-33.972602739726",
+                "payoff": -33.972602739726,
                 "currency": "USD",
-                "notionalPrincipal": "-4333.97260273973",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -4333.97260273973,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "PR",
-                "payoff": "-673.402469506474",
+                "payoff": -673.402469506474,
                 "currency": "USD",
-                "notionalPrincipal": "-3660.57013323325",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "-26.597530493526"
+                "notionalPrincipal": -3660.57013323325,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": -26.597530493526
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "IP",
-                "payoff": "-26.597530493526",
+                "payoff": -26.597530493526,
                 "currency": "USD",
-                "notionalPrincipal": "-3660.57013323325",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -3660.57013323325,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "PR",
-                "payoff": "-675.128181012552",
+                "payoff": -675.128181012552,
                 "currency": "USD",
-                "notionalPrincipal": "-2985.4419522207",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "-24.8718189874479"
+                "notionalPrincipal": -2985.4419522207,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": -24.8718189874479
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "IP",
-                "payoff": "-24.8718189874479",
+                "payoff": -24.8718189874479,
                 "currency": "USD",
-                "notionalPrincipal": "-2985.4419522207",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -2985.4419522207,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "PR",
-                "payoff": "-680.369696752522",
+                "payoff": -680.369696752522,
                 "currency": "USD",
-                "notionalPrincipal": "-2305.07225546818",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "-19.6303032474786"
+                "notionalPrincipal": -2305.07225546818,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": -19.6303032474786
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "IP",
-                "payoff": "-19.6303032474786",
+                "payoff": -19.6303032474786,
                 "currency": "USD",
-                "notionalPrincipal": "-2305.07225546818",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -2305.07225546818,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "PR",
-                "payoff": "-684.338139195723",
+                "payoff": -684.338139195723,
                 "currency": "USD",
-                "notionalPrincipal": "-1620.73411627246",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "-15.6618608042769"
+                "notionalPrincipal": -1620.73411627246,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": -15.6618608042769
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "IP",
-                "payoff": "-15.6618608042769",
+                "payoff": -15.6618608042769,
                 "currency": "USD",
-                "notionalPrincipal": "-1620.73411627246",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -1620.73411627246,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "PR",
-                "payoff": "-689.343118139578",
+                "payoff": -689.343118139578,
                 "currency": "USD",
-                "notionalPrincipal": "-931.390998132877",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "-10.6568818604216"
+                "notionalPrincipal": -931.390998132877,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": -10.6568818604216
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "IP",
-                "payoff": "-10.6568818604216",
+                "payoff": -10.6568818604216,
                 "currency": "USD",
-                "notionalPrincipal": "-931.390998132877",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -931.390998132877,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "PR",
-                "payoff": "-693.671644725015",
+                "payoff": -693.671644725015,
                 "currency": "USD",
-                "notionalPrincipal": "-237.719353407862",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "-6.32835527498503"
+                "notionalPrincipal": -237.719353407862,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": -6.32835527498503
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "IP",
-                "payoff": "-6.32835527498503",
+                "payoff": -6.32835527498503,
                 "currency": "USD",
-                "notionalPrincipal": "-237.719353407862",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -237.719353407862,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "IP",
-                "payoff": "-1.61518903137397",
+                "payoff": -1.61518903137397,
                 "currency": "USD",
-                "notionalPrincipal": "-237.719353407862",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -237.719353407862,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-09-01T00:00",
                 "eventType": "MD",
-                "payoff": "-237.719353407862",
+                "payoff": -237.719353407862,
                 "currency": "USD",
-                "notionalPrincipal": "0.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 0.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             }
         ]
     },
@@ -10137,137 +10137,137 @@
             {
                 "eventDate": "2013-01-01T00:00",
                 "eventType": "IED",
-                "payoff": "5000.0",
+                "payoff": 5000.0,
                 "currency": "USD",
-                "notionalPrincipal": "-5000.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -5000.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "PR",
-                "payoff": "-666.027397260274",
+                "payoff": -666.027397260274,
                 "currency": "USD",
-                "notionalPrincipal": "-4333.97260273973",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "-33.972602739726"
+                "notionalPrincipal": -4333.97260273973,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": -33.972602739726
             },
             {
                 "eventDate": "2013-02-01T00:00",
                 "eventType": "IP",
-                "payoff": "-33.972602739726",
+                "payoff": -33.972602739726,
                 "currency": "USD",
-                "notionalPrincipal": "-4333.97260273973",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -4333.97260273973,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "PR",
-                "payoff": "-673.402469506474",
+                "payoff": -673.402469506474,
                 "currency": "USD",
-                "notionalPrincipal": "-3660.57013323325",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "-26.597530493526"
+                "notionalPrincipal": -3660.57013323325,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": -26.597530493526
             },
             {
                 "eventDate": "2013-03-01T00:00",
                 "eventType": "IP",
-                "payoff": "-26.597530493526",
+                "payoff": -26.597530493526,
                 "currency": "USD",
-                "notionalPrincipal": "-3660.57013323325",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -3660.57013323325,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "PR",
-                "payoff": "-675.128181012552",
+                "payoff": -675.128181012552,
                 "currency": "USD",
-                "notionalPrincipal": "-2985.4419522207",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "-24.8718189874479"
+                "notionalPrincipal": -2985.4419522207,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": -24.8718189874479
             },
             {
                 "eventDate": "2013-04-01T00:00",
                 "eventType": "IP",
-                "payoff": "-24.8718189874479",
+                "payoff": -24.8718189874479,
                 "currency": "USD",
-                "notionalPrincipal": "-2985.4419522207",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -2985.4419522207,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "PR",
-                "payoff": "-680.369696752522",
+                "payoff": -680.369696752522,
                 "currency": "USD",
-                "notionalPrincipal": "-2305.07225546818",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "-19.6303032474786"
+                "notionalPrincipal": -2305.07225546818,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": -19.6303032474786
             },
             {
                 "eventDate": "2013-05-01T00:00",
                 "eventType": "IP",
-                "payoff": "-19.6303032474786",
+                "payoff": -19.6303032474786,
                 "currency": "USD",
-                "notionalPrincipal": "-2305.07225546818",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -2305.07225546818,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "PR",
-                "payoff": "-684.338139195723",
+                "payoff": -684.338139195723,
                 "currency": "USD",
-                "notionalPrincipal": "-1620.73411627246",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "-15.6618608042769"
+                "notionalPrincipal": -1620.73411627246,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": -15.6618608042769
             },
             {
                 "eventDate": "2013-06-01T00:00",
                 "eventType": "IP",
-                "payoff": "-15.6618608042769",
+                "payoff": -15.6618608042769,
                 "currency": "USD",
-                "notionalPrincipal": "-1620.73411627246",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -1620.73411627246,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "PR",
-                "payoff": "-689.343118139578",
+                "payoff": -689.343118139578,
                 "currency": "USD",
-                "notionalPrincipal": "-931.390998132877",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "-10.6568818604216"
+                "notionalPrincipal": -931.390998132877,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": -10.6568818604216
             },
             {
                 "eventDate": "2013-07-01T00:00",
                 "eventType": "IP",
-                "payoff": "-10.6568818604216",
+                "payoff": -10.6568818604216,
                 "currency": "USD",
-                "notionalPrincipal": "-931.390998132877",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -931.390998132877,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "IP",
-                "payoff": "-6.32835527498503",
+                "payoff": -6.32835527498503,
                 "currency": "USD",
-                "notionalPrincipal": "-931.390998132877",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": -931.390998132877,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             },
             {
                 "eventDate": "2013-08-01T00:00",
                 "eventType": "MD",
-                "payoff": "-931.390998132877",
+                "payoff": -931.390998132877,
                 "currency": "USD",
-                "notionalPrincipal": "0.0",
-                "nominalInterestRate": "0.08",
-                "accruedInterest": "0.0"
+                "notionalPrincipal": 0.0,
+                "nominalInterestRate": 0.08,
+                "accruedInterest": 0.0
             }
         ]
     }

--- a/tests/actus-tests-nam.json
+++ b/tests/actus-tests-nam.json
@@ -82,236 +82,236 @@
         {
           "eventDate": "2013-01-01T00:00",
           "eventType": "IED",
-          "payoff": "-5000.0",
+          "payoff": -5000.0,
           "currency": "USD",
-          "notionalPrincipal": "5000.0",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 5000.0,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-02-01T00:00",
           "eventType": "PR",
-          "payoff": "466.0273972602",
+          "payoff": 466.0273972602,
           "currency": "USD",
-          "notionalPrincipal": "4533.9726027397",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "33.9726027397"
+          "notionalPrincipal": 4533.9726027397,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 33.9726027397
         },
         {
           "eventDate": "2013-02-01T00:00",
           "eventType": "IP",
-          "payoff": "33.9726027397",
+          "payoff": 33.9726027397,
           "currency": "USD",
-          "notionalPrincipal": "4533.9726027397",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4533.9726027397,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-03-01T00:00",
           "eventType": "PR",
-          "payoff": "472.1750722462",
+          "payoff": 472.1750722462,
           "currency": "USD",
-          "notionalPrincipal": "4061.7975304935",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "27.8249277537"
+          "notionalPrincipal": 4061.7975304935,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 27.8249277537
         },
         {
           "eventDate": "2013-03-01T00:00",
           "eventType": "IP",
-          "payoff": "27.8249277537",
+          "payoff": 27.8249277537,
           "currency": "USD",
-          "notionalPrincipal": "4061.7975304935",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4061.7975304935,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-04-01T00:00",
           "eventType": "PR",
-          "payoff": "472.4020332174",
+          "payoff": 472.4020332174,
           "currency": "USD",
-          "notionalPrincipal": "3589.395497276",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "27.5979667825"
+          "notionalPrincipal": 3589.395497276,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 27.5979667825
         },
         {
           "eventDate": "2013-04-01T00:00",
           "eventType": "IP",
-          "payoff": "27.5979667825",
+          "payoff": 27.5979667825,
           "currency": "USD",
-          "notionalPrincipal": "3589.395497276",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 3589.395497276,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-04-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "3589.395497276",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 3589.395497276,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-05-01T00:00",
           "eventType": "PR",
-          "payoff": "467.3803895752",
+          "payoff": 467.3803895752,
           "currency": "USD",
-          "notionalPrincipal": "3122.0151077008",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "32.6196104247"
+          "notionalPrincipal": 3122.0151077008,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 32.6196104247
         },
         {
           "eventDate": "2013-05-01T00:00",
           "eventType": "IP",
-          "payoff": "32.6196104247",
+          "payoff": 32.6196104247,
           "currency": "USD",
-          "notionalPrincipal": "3122.0151077008",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 3122.0151077008,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-06-01T00:00",
           "eventType": "PR",
-          "payoff": "470.6820975328",
+          "payoff": 470.6820975328,
           "currency": "USD",
-          "notionalPrincipal": "2651.3330101679",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "29.3179024671"
+          "notionalPrincipal": 2651.3330101679,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 29.3179024671
         },
         {
           "eventDate": "2013-06-01T00:00",
           "eventType": "IP",
-          "payoff": "29.3179024671",
+          "payoff": 29.3179024671,
           "currency": "USD",
-          "notionalPrincipal": "2651.3330101679",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 2651.3330101679,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-07-01T00:00",
           "eventType": "PR",
-          "payoff": "475.9052882404",
+          "payoff": 475.9052882404,
           "currency": "USD",
-          "notionalPrincipal": "2175.4277219275",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "24.0947117595"
+          "notionalPrincipal": 2175.4277219275,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 24.0947117595
         },
         {
           "eventDate": "2013-07-01T00:00",
           "eventType": "IP",
-          "payoff": "24.0947117595",
+          "payoff": 24.0947117595,
           "currency": "USD",
-          "notionalPrincipal": "2175.4277219275",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 2175.4277219275,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-07-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "2175.4277219275",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 2175.4277219275,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-08-01T00:00",
           "eventType": "PR",
-          "payoff": "479.3659227346",
+          "payoff": 479.3659227346,
           "currency": "USD",
-          "notionalPrincipal": "1696.0617991928",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "20.6340772653"
+          "notionalPrincipal": 1696.0617991928,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": 20.6340772653
         },
         {
           "eventDate": "2013-08-01T00:00",
           "eventType": "IP",
-          "payoff": "20.6340772653",
+          "payoff": 20.6340772653,
           "currency": "USD",
-          "notionalPrincipal": "1696.0617991928",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 1696.0617991928,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-09-01T00:00",
           "eventType": "PR",
-          "payoff": "483.9127405344",
+          "payoff": 483.9127405344,
           "currency": "USD",
-          "notionalPrincipal": "1212.1490586584",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "16.0872594655"
+          "notionalPrincipal": 1212.1490586584,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": 16.0872594655
         },
         {
           "eventDate": "2013-09-01T00:00",
           "eventType": "IP",
-          "payoff": "16.0872594655",
+          "payoff": 16.0872594655,
           "currency": "USD",
-          "notionalPrincipal": "1212.1490586584",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 1212.1490586584,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-10-01T00:00",
           "eventType": "PR",
-          "payoff": "488.8735663271",
+          "payoff": 488.8735663271,
           "currency": "USD",
-          "notionalPrincipal": "723.2754923313",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "11.1264336728"
+          "notionalPrincipal": 723.2754923313,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": 11.1264336728
         },
         {
           "eventDate": "2013-10-01T00:00",
           "eventType": "IP",
-          "payoff": "11.1264336728",
+          "payoff": 11.1264336728,
           "currency": "USD",
-          "notionalPrincipal": "723.2754923313",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 723.2754923313,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-10-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "723.2754923313",
-          "nominalInterestRate": "0.1127901234",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 723.2754923313,
+          "nominalInterestRate": 0.1127901234,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-11-01T00:00",
           "eventType": "PR",
-          "payoff": "493.0714293307",
+          "payoff": 493.0714293307,
           "currency": "USD",
-          "notionalPrincipal": "230.2040630006",
-          "nominalInterestRate": "0.1127901234",
-          "accruedInterest": "6.9285706692"
+          "notionalPrincipal": 230.2040630006,
+          "nominalInterestRate": 0.1127901234,
+          "accruedInterest": 6.9285706692
         },
         {
           "eventDate": "2013-11-01T00:00",
           "eventType": "IP",
-          "payoff": "6.9285706692",
+          "payoff": 6.9285706692,
           "currency": "USD",
-          "notionalPrincipal": "230.2040630006",
-          "nominalInterestRate": "0.1127901234",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 230.2040630006,
+          "nominalInterestRate": 0.1127901234,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-12-01T00:00",
           "eventType": "IP",
-          "payoff": "2.1340886043",
+          "payoff": 2.1340886043,
           "currency": "USD",
-          "notionalPrincipal": "230.2040630006",
-          "nominalInterestRate": "0.1127901234",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 230.2040630006,
+          "nominalInterestRate": 0.1127901234,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-12-01T00:00",
           "eventType": "MD",
-          "payoff": "230.2040630006",
+          "payoff": 230.2040630006,
           "currency": "USD",
-          "notionalPrincipal": "0.0",
-          "nominalInterestRate": "0.1127901234",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 0.0,
+          "nominalInterestRate": 0.1127901234,
+          "accruedInterest": 0.0
         }
       ]
     },
@@ -1302,236 +1302,236 @@
         {
           "eventDate": "2013-01-01T00:00",
           "eventType": "IED",
-          "payoff": "-5000.0",
+          "payoff": -5000.0,
           "currency": "USD",
-          "notionalPrincipal": "5000.0",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 5000.0,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-01-01T00:00",
           "eventType": "PR",
-          "payoff": "500.0",
+          "payoff": 500.0,
           "currency": "USD",
-          "notionalPrincipal": "4500.0",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4500.0,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-01-01T00:00",
           "eventType": "IP",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "4500.0",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4500.0,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-02-01T00:00",
           "eventType": "PR",
-          "payoff": "469.4246575342",
+          "payoff": 469.4246575342,
           "currency": "USD",
-          "notionalPrincipal": "4030.5753424657",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "30.5753424657"
+          "notionalPrincipal": 4030.5753424657,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 30.5753424657
         },
         {
           "eventDate": "2013-02-01T00:00",
           "eventType": "IP",
-          "payoff": "30.5753424657",
+          "payoff": 30.5753424657,
           "currency": "USD",
-          "notionalPrincipal": "4030.5753424657",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4030.5753424657,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-03-01T00:00",
           "eventType": "PR",
-          "payoff": "475.2644143366",
+          "payoff": 475.2644143366,
           "currency": "USD",
-          "notionalPrincipal": "3555.3109281291",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "24.7355856633"
+          "notionalPrincipal": 3555.3109281291,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 24.7355856633
         },
         {
           "eventDate": "2013-03-01T00:00",
           "eventType": "IP",
-          "payoff": "24.7355856633",
+          "payoff": 24.7355856633,
           "currency": "USD",
-          "notionalPrincipal": "3555.3109281291",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 3555.3109281291,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-04-01T00:00",
           "eventType": "PR",
-          "payoff": "475.8433668444",
+          "payoff": 475.8433668444,
           "currency": "USD",
-          "notionalPrincipal": "3079.4675612846",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "24.1566331555"
+          "notionalPrincipal": 3079.4675612846,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 24.1566331555
         },
         {
           "eventDate": "2013-04-01T00:00",
           "eventType": "IP",
-          "payoff": "24.1566331555",
+          "payoff": 24.1566331555,
           "currency": "USD",
-          "notionalPrincipal": "3079.4675612846",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 3079.4675612846,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-04-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "3079.4675612846",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 3079.4675612846,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-05-01T00:00",
           "eventType": "PR",
-          "payoff": "472.014498753",
+          "payoff": 472.014498753,
           "currency": "USD",
-          "notionalPrincipal": "2607.4530625315",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "27.9855012469"
+          "notionalPrincipal": 2607.4530625315,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 27.9855012469
         },
         {
           "eventDate": "2013-05-01T00:00",
           "eventType": "IP",
-          "payoff": "27.9855012469",
+          "payoff": 27.9855012469,
           "currency": "USD",
-          "notionalPrincipal": "2607.4530625315",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 2607.4530625315,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-06-01T00:00",
           "eventType": "PR",
-          "payoff": "475.5141945385",
+          "payoff": 475.5141945385,
           "currency": "USD",
-          "notionalPrincipal": "2131.938867993",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "24.4858054614"
+          "notionalPrincipal": 2131.938867993,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 24.4858054614
         },
         {
           "eventDate": "2013-06-01T00:00",
           "eventType": "IP",
-          "payoff": "24.4858054614",
+          "payoff": 24.4858054614,
           "currency": "USD",
-          "notionalPrincipal": "2131.938867993",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 2131.938867993,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-07-01T00:00",
           "eventType": "PR",
-          "payoff": "480.6254241484",
+          "payoff": 480.6254241484,
           "currency": "USD",
-          "notionalPrincipal": "1651.3134438446",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "19.3745758515"
+          "notionalPrincipal": 1651.3134438446,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 19.3745758515
         },
         {
           "eventDate": "2013-07-01T00:00",
           "eventType": "IP",
-          "payoff": "19.3745758515",
+          "payoff": 19.3745758515,
           "currency": "USD",
-          "notionalPrincipal": "1651.3134438446",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 1651.3134438446,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-07-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "1651.3134438446",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 1651.3134438446,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-08-01T00:00",
           "eventType": "PR",
-          "payoff": "484.3371816741",
+          "payoff": 484.3371816741,
           "currency": "USD",
-          "notionalPrincipal": "1166.9762621704",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "15.6628183258"
+          "notionalPrincipal": 1166.9762621704,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": 15.6628183258
         },
         {
           "eventDate": "2013-08-01T00:00",
           "eventType": "IP",
-          "payoff": "15.6628183258",
+          "payoff": 15.6628183258,
           "currency": "USD",
-          "notionalPrincipal": "1166.9762621704",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 1166.9762621704,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-09-01T00:00",
           "eventType": "PR",
-          "payoff": "488.931152197",
+          "payoff": 488.931152197,
           "currency": "USD",
-          "notionalPrincipal": "678.0451099734",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "11.0688478029"
+          "notionalPrincipal": 678.0451099734,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": 11.0688478029
         },
         {
           "eventDate": "2013-09-01T00:00",
           "eventType": "IP",
-          "payoff": "11.0688478029",
+          "payoff": 11.0688478029,
           "currency": "USD",
-          "notionalPrincipal": "678.0451099734",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 678.0451099734,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-10-01T00:00",
           "eventType": "PR",
-          "payoff": "493.7761582295",
+          "payoff": 493.7761582295,
           "currency": "USD",
-          "notionalPrincipal": "184.2689517439",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "6.2238417704"
+          "notionalPrincipal": 184.2689517439,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": 6.2238417704
         },
         {
           "eventDate": "2013-10-01T00:00",
           "eventType": "IP",
-          "payoff": "6.2238417704",
+          "payoff": 6.2238417704,
           "currency": "USD",
-          "notionalPrincipal": "184.2689517439",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 184.2689517439,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-10-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "184.2689517439",
-          "nominalInterestRate": "0.1127901234",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 184.2689517439,
+          "nominalInterestRate": 0.1127901234,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-11-01T00:00",
           "eventType": "IP",
-          "payoff": "1.765192472",
+          "payoff": 1.765192472,
           "currency": "USD",
-          "notionalPrincipal": "184.2689517439",
-          "nominalInterestRate": "0.1127901234",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 184.2689517439,
+          "nominalInterestRate": 0.1127901234,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-11-01T00:00",
           "eventType": "MD",
-          "payoff": "184.2689517439",
+          "payoff": 184.2689517439,
           "currency": "USD",
-          "notionalPrincipal": "0.0",
-          "nominalInterestRate": "0.1127901234",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 0.0,
+          "nominalInterestRate": 0.1127901234,
+          "accruedInterest": 0.0
         }
       ]
     },
@@ -1618,614 +1618,614 @@
         {
           "eventDate": "2013-01-01T00:00",
           "eventType": "IED",
-          "payoff": "-50000.0",
+          "payoff": -50000.0,
           "currency": "USD",
-          "notionalPrincipal": "50000.0",
-          "nominalInterestRate": "0.05",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 50000.0,
+          "nominalInterestRate": 0.05,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-02-01T00:00",
           "eventType": "PR",
-          "payoff": "1791.6666666666",
+          "payoff": 1791.6666666666,
           "currency": "USD",
-          "notionalPrincipal": "48208.3333333333",
-          "nominalInterestRate": "0.05",
-          "accruedInterest": "208.3333333333"
+          "notionalPrincipal": 48208.3333333333,
+          "nominalInterestRate": 0.05,
+          "accruedInterest": 208.3333333333
         },
         {
           "eventDate": "2013-02-01T00:00",
           "eventType": "IP",
-          "payoff": "208.3333333333",
+          "payoff": 208.3333333333,
           "currency": "USD",
-          "notionalPrincipal": "48208.3333333333",
-          "nominalInterestRate": "0.05",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 48208.3333333333,
+          "nominalInterestRate": 0.05,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-03-01T00:00",
           "eventType": "PR",
-          "payoff": "1799.1319444444",
+          "payoff": 1799.1319444444,
           "currency": "USD",
-          "notionalPrincipal": "46409.2013888888",
-          "nominalInterestRate": "0.05",
-          "accruedInterest": "200.8680555555"
+          "notionalPrincipal": 46409.2013888888,
+          "nominalInterestRate": 0.05,
+          "accruedInterest": 200.8680555555
         },
         {
           "eventDate": "2013-03-01T00:00",
           "eventType": "IP",
-          "payoff": "200.8680555555",
+          "payoff": 200.8680555555,
           "currency": "USD",
-          "notionalPrincipal": "46409.2013888888",
-          "nominalInterestRate": "0.05",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 46409.2013888888,
+          "nominalInterestRate": 0.05,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-04-01T00:00",
           "eventType": "PR",
-          "payoff": "1806.6283275462",
+          "payoff": 1806.6283275462,
           "currency": "USD",
-          "notionalPrincipal": "44602.5730613425",
-          "nominalInterestRate": "0.05",
-          "accruedInterest": "193.3716724537"
+          "notionalPrincipal": 44602.5730613425,
+          "nominalInterestRate": 0.05,
+          "accruedInterest": 193.3716724537
         },
         {
           "eventDate": "2013-04-01T00:00",
           "eventType": "IP",
-          "payoff": "193.3716724537",
+          "payoff": 193.3716724537,
           "currency": "USD",
-          "notionalPrincipal": "44602.5730613425",
-          "nominalInterestRate": "0.05",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 44602.5730613425,
+          "nominalInterestRate": 0.05,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-04-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "44602.5730613425",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 44602.5730613425,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-05-01T00:00",
           "eventType": "PR",
-          "payoff": "1589.0322589121",
+          "payoff": 1589.0322589121,
           "currency": "USD",
-          "notionalPrincipal": "43013.5408024304",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "410.9677410878"
+          "notionalPrincipal": 43013.5408024304,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 410.9677410878
         },
         {
           "eventDate": "2013-05-01T00:00",
           "eventType": "IP",
-          "payoff": "410.9677410878",
+          "payoff": 410.9677410878,
           "currency": "USD",
-          "notionalPrincipal": "43013.5408024304",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 43013.5408024304,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-06-01T00:00",
           "eventType": "PR",
-          "payoff": "1603.6735890673",
+          "payoff": 1603.6735890673,
           "currency": "USD",
-          "notionalPrincipal": "41409.8672133631",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "396.3264109326"
+          "notionalPrincipal": 41409.8672133631,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 396.3264109326
         },
         {
           "eventDate": "2013-06-01T00:00",
           "eventType": "IP",
-          "payoff": "396.3264109326",
+          "payoff": 396.3264109326,
           "currency": "USD",
-          "notionalPrincipal": "41409.8672133631",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 41409.8672133631,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-07-01T00:00",
           "eventType": "PR",
-          "payoff": "1618.449824318",
+          "payoff": 1618.449824318,
           "currency": "USD",
-          "notionalPrincipal": "39791.417389045",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "381.5501756819"
+          "notionalPrincipal": 39791.417389045,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 381.5501756819
         },
         {
           "eventDate": "2013-07-01T00:00",
           "eventType": "IP",
-          "payoff": "381.5501756819",
+          "payoff": 381.5501756819,
           "currency": "USD",
-          "notionalPrincipal": "39791.417389045",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 39791.417389045,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-07-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "39791.417389045",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 39791.417389045,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-08-01T00:00",
           "eventType": "PR",
-          "payoff": "1629.6778171797",
+          "payoff": 1629.6778171797,
           "currency": "USD",
-          "notionalPrincipal": "38161.7395718653",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "370.3221828202"
+          "notionalPrincipal": 38161.7395718653,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": 370.3221828202
         },
         {
           "eventDate": "2013-08-01T00:00",
           "eventType": "IP",
-          "payoff": "370.3221828202",
+          "payoff": 370.3221828202,
           "currency": "USD",
-          "notionalPrincipal": "38161.7395718653",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 38161.7395718653,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-09-01T00:00",
           "eventType": "PR",
-          "payoff": "1644.8445512684",
+          "payoff": 1644.8445512684,
           "currency": "USD",
-          "notionalPrincipal": "36516.8950205969",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "355.1554487315"
+          "notionalPrincipal": 36516.8950205969,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": 355.1554487315
         },
         {
           "eventDate": "2013-09-01T00:00",
           "eventType": "IP",
-          "payoff": "355.1554487315",
+          "payoff": 355.1554487315,
           "currency": "USD",
-          "notionalPrincipal": "36516.8950205969",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 36516.8950205969,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-10-01T00:00",
           "eventType": "PR",
-          "payoff": "1660.1524358474",
+          "payoff": 1660.1524358474,
           "currency": "USD",
-          "notionalPrincipal": "34856.7425847495",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "339.8475641525"
+          "notionalPrincipal": 34856.7425847495,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": 339.8475641525
         },
         {
           "eventDate": "2013-10-01T00:00",
           "eventType": "IP",
-          "payoff": "339.8475641525",
+          "payoff": 339.8475641525,
           "currency": "USD",
-          "notionalPrincipal": "34856.7425847495",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 34856.7425847495,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-10-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "34856.7425847495",
-          "nominalInterestRate": "0.1127901234",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 34856.7425847495,
+          "nominalInterestRate": 0.1127901234,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-11-01T00:00",
           "eventType": "PR",
-          "payoff": "1672.3753083803",
+          "payoff": 1672.3753083803,
           "currency": "USD",
-          "notionalPrincipal": "33184.3672763691",
-          "nominalInterestRate": "0.1127901234",
-          "accruedInterest": "327.6246916196"
+          "notionalPrincipal": 33184.3672763691,
+          "nominalInterestRate": 0.1127901234,
+          "accruedInterest": 327.6246916196
         },
         {
           "eventDate": "2013-11-01T00:00",
           "eventType": "IP",
-          "payoff": "327.6246916196",
+          "payoff": 327.6246916196,
           "currency": "USD",
-          "notionalPrincipal": "33184.3672763691",
-          "nominalInterestRate": "0.1127901234",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 33184.3672763691,
+          "nominalInterestRate": 0.1127901234,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-12-01T00:00",
           "eventType": "PR",
-          "payoff": "1688.0942598385",
+          "payoff": 1688.0942598385,
           "currency": "USD",
-          "notionalPrincipal": "31496.2730165305",
-          "nominalInterestRate": "0.1127901234",
-          "accruedInterest": "311.9057401614"
+          "notionalPrincipal": 31496.2730165305,
+          "nominalInterestRate": 0.1127901234,
+          "accruedInterest": 311.9057401614
         },
         {
           "eventDate": "2013-12-01T00:00",
           "eventType": "IP",
-          "payoff": "311.9057401614",
+          "payoff": 311.9057401614,
           "currency": "USD",
-          "notionalPrincipal": "31496.2730165305",
-          "nominalInterestRate": "0.1127901234",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 31496.2730165305,
+          "nominalInterestRate": 0.1127901234,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-01-01T00:00",
           "eventType": "PR",
-          "payoff": "1703.960956503",
+          "payoff": 1703.960956503,
           "currency": "USD",
-          "notionalPrincipal": "29792.3120600275",
-          "nominalInterestRate": "0.1127901234",
-          "accruedInterest": "296.0390434969"
+          "notionalPrincipal": 29792.3120600275,
+          "nominalInterestRate": 0.1127901234,
+          "accruedInterest": 296.0390434969
         },
         {
           "eventDate": "2014-01-01T00:00",
           "eventType": "IP",
-          "payoff": "296.0390434969",
+          "payoff": 296.0390434969,
           "currency": "USD",
-          "notionalPrincipal": "29792.3120600275",
-          "nominalInterestRate": "0.1127901234",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 29792.3120600275,
+          "nominalInterestRate": 0.1127901234,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-01-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "29792.3120600275",
-          "nominalInterestRate": "0.1139012345",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 29792.3120600275,
+          "nominalInterestRate": 0.1139012345,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-02-01T00:00",
           "eventType": "PR",
-          "payoff": "1717.2182396442",
+          "payoff": 1717.2182396442,
           "currency": "USD",
-          "notionalPrincipal": "28075.0938203832",
-          "nominalInterestRate": "0.1139012345",
-          "accruedInterest": "282.7817603557"
+          "notionalPrincipal": 28075.0938203832,
+          "nominalInterestRate": 0.1139012345,
+          "accruedInterest": 282.7817603557
         },
         {
           "eventDate": "2014-02-01T00:00",
           "eventType": "IP",
-          "payoff": "282.7817603557",
+          "payoff": 282.7817603557,
           "currency": "USD",
-          "notionalPrincipal": "28075.0938203832",
-          "nominalInterestRate": "0.1139012345",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 28075.0938203832,
+          "nominalInterestRate": 0.1139012345,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-03-01T00:00",
           "eventType": "PR",
-          "payoff": "1733.5176794373",
+          "payoff": 1733.5176794373,
           "currency": "USD",
-          "notionalPrincipal": "26341.5761409459",
-          "nominalInterestRate": "0.1139012345",
-          "accruedInterest": "266.4823205626"
+          "notionalPrincipal": 26341.5761409459,
+          "nominalInterestRate": 0.1139012345,
+          "accruedInterest": 266.4823205626
         },
         {
           "eventDate": "2014-03-01T00:00",
           "eventType": "IP",
-          "payoff": "266.4823205626",
+          "payoff": 266.4823205626,
           "currency": "USD",
-          "notionalPrincipal": "26341.5761409459",
-          "nominalInterestRate": "0.1139012345",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 26341.5761409459,
+          "nominalInterestRate": 0.1139012345,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-04-01T00:00",
           "eventType": "PR",
-          "payoff": "1749.9718297568",
+          "payoff": 1749.9718297568,
           "currency": "USD",
-          "notionalPrincipal": "24591.604311189",
-          "nominalInterestRate": "0.1139012345",
-          "accruedInterest": "250.0281702431"
+          "notionalPrincipal": 24591.604311189,
+          "nominalInterestRate": 0.1139012345,
+          "accruedInterest": 250.0281702431
         },
         {
           "eventDate": "2014-04-01T00:00",
           "eventType": "IP",
-          "payoff": "250.0281702431",
+          "payoff": 250.0281702431,
           "currency": "USD",
-          "notionalPrincipal": "24591.604311189",
-          "nominalInterestRate": "0.1139012345",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 24591.604311189,
+          "nominalInterestRate": 0.1139012345,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-04-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "24591.604311189",
-          "nominalInterestRate": "0.1150123456",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 24591.604311189,
+          "nominalInterestRate": 0.1150123456,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-05-01T00:00",
           "eventType": "PR",
-          "payoff": "1764.30515868",
+          "payoff": 1764.30515868,
           "currency": "USD",
-          "notionalPrincipal": "22827.299152509",
-          "nominalInterestRate": "0.1150123456",
-          "accruedInterest": "235.6948413199"
+          "notionalPrincipal": 22827.299152509,
+          "nominalInterestRate": 0.1150123456,
+          "accruedInterest": 235.6948413199
         },
         {
           "eventDate": "2014-05-01T00:00",
           "eventType": "IP",
-          "payoff": "235.6948413199",
+          "payoff": 235.6948413199,
           "currency": "USD",
-          "notionalPrincipal": "22827.299152509",
-          "nominalInterestRate": "0.1150123456",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 22827.299152509,
+          "nominalInterestRate": 0.1150123456,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-06-01T00:00",
           "eventType": "PR",
-          "payoff": "1781.2148982461",
+          "payoff": 1781.2148982461,
           "currency": "USD",
-          "notionalPrincipal": "21046.0842542629",
-          "nominalInterestRate": "0.1150123456",
-          "accruedInterest": "218.7851017538"
+          "notionalPrincipal": 21046.0842542629,
+          "nominalInterestRate": 0.1150123456,
+          "accruedInterest": 218.7851017538
         },
         {
           "eventDate": "2014-06-01T00:00",
           "eventType": "IP",
-          "payoff": "218.7851017538",
+          "payoff": 218.7851017538,
           "currency": "USD",
-          "notionalPrincipal": "21046.0842542629",
-          "nominalInterestRate": "0.1150123456",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 21046.0842542629,
+          "nominalInterestRate": 0.1150123456,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-07-01T00:00",
           "eventType": "PR",
-          "payoff": "1798.2867068799",
+          "payoff": 1798.2867068799,
           "currency": "USD",
-          "notionalPrincipal": "19247.797547383",
-          "nominalInterestRate": "0.1150123456",
-          "accruedInterest": "201.71329312"
+          "notionalPrincipal": 19247.797547383,
+          "nominalInterestRate": 0.1150123456,
+          "accruedInterest": 201.71329312
         },
         {
           "eventDate": "2014-07-01T00:00",
           "eventType": "IP",
-          "payoff": "201.71329312",
+          "payoff": 201.71329312,
           "currency": "USD",
-          "notionalPrincipal": "19247.797547383",
-          "nominalInterestRate": "0.1150123456",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 19247.797547383,
+          "nominalInterestRate": 0.1150123456,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-07-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "19247.797547383",
-          "nominalInterestRate": "0.1161234567",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 19247.797547383,
+          "nominalInterestRate": 0.1161234567,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-08-01T00:00",
           "eventType": "PR",
-          "payoff": "1813.7399344334",
+          "payoff": 1813.7399344334,
           "currency": "USD",
-          "notionalPrincipal": "17434.0576129495",
-          "nominalInterestRate": "0.1161234567",
-          "accruedInterest": "186.2600655665"
+          "notionalPrincipal": 17434.0576129495,
+          "nominalInterestRate": 0.1161234567,
+          "accruedInterest": 186.2600655665
         },
         {
           "eventDate": "2014-08-01T00:00",
           "eventType": "IP",
-          "payoff": "186.2600655665",
+          "payoff": 186.2600655665,
           "currency": "USD",
-          "notionalPrincipal": "17434.0576129495",
-          "nominalInterestRate": "0.1161234567",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 17434.0576129495,
+          "nominalInterestRate": 0.1161234567,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-09-01T00:00",
           "eventType": "PR",
-          "payoff": "1831.2914136755",
+          "payoff": 1831.2914136755,
           "currency": "USD",
-          "notionalPrincipal": "15602.766199274",
-          "nominalInterestRate": "0.1161234567",
-          "accruedInterest": "168.7085863244"
+          "notionalPrincipal": 15602.766199274,
+          "nominalInterestRate": 0.1161234567,
+          "accruedInterest": 168.7085863244
         },
         {
           "eventDate": "2014-09-01T00:00",
           "eventType": "IP",
-          "payoff": "168.7085863244",
+          "payoff": 168.7085863244,
           "currency": "USD",
-          "notionalPrincipal": "15602.766199274",
-          "nominalInterestRate": "0.1161234567",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 15602.766199274,
+          "nominalInterestRate": 0.1161234567,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-10-01T00:00",
           "eventType": "PR",
-          "payoff": "1849.0127377876",
+          "payoff": 1849.0127377876,
           "currency": "USD",
-          "notionalPrincipal": "13753.7534614863",
-          "nominalInterestRate": "0.1161234567",
-          "accruedInterest": "150.9872622123"
+          "notionalPrincipal": 13753.7534614863,
+          "nominalInterestRate": 0.1161234567,
+          "accruedInterest": 150.9872622123
         },
         {
           "eventDate": "2014-10-01T00:00",
           "eventType": "IP",
-          "payoff": "150.9872622123",
+          "payoff": 150.9872622123,
           "currency": "USD",
-          "notionalPrincipal": "13753.7534614863",
-          "nominalInterestRate": "0.1161234567",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 13753.7534614863,
+          "nominalInterestRate": 0.1161234567,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-10-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "13753.7534614863",
-          "nominalInterestRate": "0.1172345679",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 13753.7534614863,
+          "nominalInterestRate": 0.1172345679,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-11-01T00:00",
           "eventType": "PR",
-          "payoff": "1865.6320546602",
+          "payoff": 1865.6320546602,
           "currency": "USD",
-          "notionalPrincipal": "11888.1214068261",
-          "nominalInterestRate": "0.1172345679",
-          "accruedInterest": "134.3679453397"
+          "notionalPrincipal": 11888.1214068261,
+          "nominalInterestRate": 0.1172345679,
+          "accruedInterest": 134.3679453397
         },
         {
           "eventDate": "2014-11-01T00:00",
           "eventType": "IP",
-          "payoff": "134.3679453397",
+          "payoff": 134.3679453397,
           "currency": "USD",
-          "notionalPrincipal": "11888.1214068261",
-          "nominalInterestRate": "0.1172345679",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 11888.1214068261,
+          "nominalInterestRate": 0.1172345679,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-12-01T00:00",
           "eventType": "PR",
-          "payoff": "1883.8584353094",
+          "payoff": 1883.8584353094,
           "currency": "USD",
-          "notionalPrincipal": "10004.2629715167",
-          "nominalInterestRate": "0.1172345679",
-          "accruedInterest": "116.1415646905"
+          "notionalPrincipal": 10004.2629715167,
+          "nominalInterestRate": 0.1172345679,
+          "accruedInterest": 116.1415646905
         },
         {
           "eventDate": "2014-12-01T00:00",
           "eventType": "IP",
-          "payoff": "116.1415646905",
+          "payoff": 116.1415646905,
           "currency": "USD",
-          "notionalPrincipal": "10004.2629715167",
-          "nominalInterestRate": "0.1172345679",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 10004.2629715167,
+          "nominalInterestRate": 0.1172345679,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2015-01-01T00:00",
           "eventType": "PR",
-          "payoff": "1902.2628794469",
+          "payoff": 1902.2628794469,
           "currency": "USD",
-          "notionalPrincipal": "8102.0000920697",
-          "nominalInterestRate": "0.1172345679",
-          "accruedInterest": "97.737120553"
+          "notionalPrincipal": 8102.0000920697,
+          "nominalInterestRate": 0.1172345679,
+          "accruedInterest": 97.737120553
         },
         {
           "eventDate": "2015-01-01T00:00",
           "eventType": "IP",
-          "payoff": "97.737120553",
+          "payoff": 97.737120553,
           "currency": "USD",
-          "notionalPrincipal": "8102.0000920697",
-          "nominalInterestRate": "0.1172345679",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 8102.0000920697,
+          "nominalInterestRate": 0.1172345679,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2015-01-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "8102.0000920697",
-          "nominalInterestRate": "0.118345679",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 8102.0000920697,
+          "nominalInterestRate": 0.118345679,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2015-02-01T00:00",
           "eventType": "PR",
-          "payoff": "1920.0969414788",
+          "payoff": 1920.0969414788,
           "currency": "USD",
-          "notionalPrincipal": "6181.9031505909",
-          "nominalInterestRate": "0.118345679",
-          "accruedInterest": "79.9030585211"
+          "notionalPrincipal": 6181.9031505909,
+          "nominalInterestRate": 0.118345679,
+          "accruedInterest": 79.9030585211
         },
         {
           "eventDate": "2015-02-01T00:00",
           "eventType": "IP",
-          "payoff": "79.9030585211",
+          "payoff": 79.9030585211,
           "currency": "USD",
-          "notionalPrincipal": "6181.9031505909",
-          "nominalInterestRate": "0.118345679",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 6181.9031505909,
+          "nominalInterestRate": 0.118345679,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2015-03-01T00:00",
           "eventType": "PR",
-          "payoff": "1939.0332061712",
+          "payoff": 1939.0332061712,
           "currency": "USD",
-          "notionalPrincipal": "4242.8699444196",
-          "nominalInterestRate": "0.118345679",
-          "accruedInterest": "60.9667938287"
+          "notionalPrincipal": 4242.8699444196,
+          "nominalInterestRate": 0.118345679,
+          "accruedInterest": 60.9667938287
         },
         {
           "eventDate": "2015-03-01T00:00",
           "eventType": "IP",
-          "payoff": "60.9667938287",
+          "payoff": 60.9667938287,
           "currency": "USD",
-          "notionalPrincipal": "4242.8699444196",
-          "nominalInterestRate": "0.118345679",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4242.8699444196,
+          "nominalInterestRate": 0.118345679,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2015-04-01T00:00",
           "eventType": "PR",
-          "payoff": "1958.1562229555",
+          "payoff": 1958.1562229555,
           "currency": "USD",
-          "notionalPrincipal": "2284.7137214641",
-          "nominalInterestRate": "0.118345679",
-          "accruedInterest": "41.8437770444"
+          "notionalPrincipal": 2284.7137214641,
+          "nominalInterestRate": 0.118345679,
+          "accruedInterest": 41.8437770444
         },
         {
           "eventDate": "2015-04-01T00:00",
           "eventType": "IP",
-          "payoff": "41.8437770444",
+          "payoff": 41.8437770444,
           "currency": "USD",
-          "notionalPrincipal": "2284.7137214641",
-          "nominalInterestRate": "0.118345679",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 2284.7137214641,
+          "nominalInterestRate": 0.118345679,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2015-04-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "2284.7137214641",
-          "nominalInterestRate": "0.1194567901",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 2284.7137214641,
+          "nominalInterestRate": 0.1194567901,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2015-05-01T00:00",
           "eventType": "PR",
-          "payoff": "1977.2562860402",
+          "payoff": 1977.2562860402,
           "currency": "USD",
-          "notionalPrincipal": "307.4574354238",
-          "nominalInterestRate": "0.1194567901",
-          "accruedInterest": "22.7437139597"
+          "notionalPrincipal": 307.4574354238,
+          "nominalInterestRate": 0.1194567901,
+          "accruedInterest": 22.7437139597
         },
         {
           "eventDate": "2015-05-01T00:00",
           "eventType": "IP",
-          "payoff": "22.7437139597",
+          "payoff": 22.7437139597,
           "currency": "USD",
-          "notionalPrincipal": "307.4574354238",
-          "nominalInterestRate": "0.1194567901",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 307.4574354238,
+          "nominalInterestRate": 0.1194567901,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2015-06-01T00:00",
           "eventType": "IP",
-          "payoff": "3.0606565279",
+          "payoff": 3.0606565279,
           "currency": "USD",
-          "notionalPrincipal": "307.4574354238",
-          "nominalInterestRate": "0.1194567901",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 307.4574354238,
+          "nominalInterestRate": 0.1194567901,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2015-06-01T00:00",
           "eventType": "MD",
-          "payoff": "307.4574354238",
+          "payoff": 307.4574354238,
           "currency": "USD",
-          "notionalPrincipal": "0.0",
-          "nominalInterestRate": "0.1194567901",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 0.0,
+          "nominalInterestRate": 0.1194567901,
+          "accruedInterest": 0.0
         }
       ]
     },
@@ -2658,236 +2658,236 @@
         {
           "eventDate": "2013-01-01T00:00",
           "eventType": "IED",
-          "payoff": "-5000.0",
+          "payoff": -5000.0,
           "currency": "USD",
-          "notionalPrincipal": "5000.0",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 5000.0,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-02-01T00:00",
           "eventType": "PR",
-          "payoff": "466.0273972602",
+          "payoff": 466.0273972602,
           "currency": "USD",
-          "notionalPrincipal": "4533.9726027397",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "33.9726027397"
+          "notionalPrincipal": 4533.9726027397,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 33.9726027397
         },
         {
           "eventDate": "2013-02-01T00:00",
           "eventType": "IP",
-          "payoff": "33.9726027397",
+          "payoff": 33.9726027397,
           "currency": "USD",
-          "notionalPrincipal": "4533.9726027397",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4533.9726027397,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-03-01T00:00",
           "eventType": "PR",
-          "payoff": "472.1750722462",
+          "payoff": 472.1750722462,
           "currency": "USD",
-          "notionalPrincipal": "4061.7975304935",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "27.8249277537"
+          "notionalPrincipal": 4061.7975304935,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 27.8249277537
         },
         {
           "eventDate": "2013-03-01T00:00",
           "eventType": "IP",
-          "payoff": "27.8249277537",
+          "payoff": 27.8249277537,
           "currency": "USD",
-          "notionalPrincipal": "4061.7975304935",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4061.7975304935,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-04-01T00:00",
           "eventType": "PR",
-          "payoff": "472.4020332174",
+          "payoff": 472.4020332174,
           "currency": "USD",
-          "notionalPrincipal": "3589.395497276",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "27.5979667825"
+          "notionalPrincipal": 3589.395497276,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 27.5979667825
         },
         {
           "eventDate": "2013-04-01T00:00",
           "eventType": "IP",
-          "payoff": "27.5979667825",
+          "payoff": 27.5979667825,
           "currency": "USD",
-          "notionalPrincipal": "3589.395497276",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 3589.395497276,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-05-01T00:00",
           "eventType": "PR",
-          "payoff": "476.3984953603",
+          "payoff": 476.3984953603,
           "currency": "USD",
-          "notionalPrincipal": "3112.9970019156",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "23.6015046396"
+          "notionalPrincipal": 3112.9970019156,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 23.6015046396
         },
         {
           "eventDate": "2013-05-01T00:00",
           "eventType": "IP",
-          "payoff": "23.6015046396",
+          "payoff": 23.6015046396,
           "currency": "USD",
-          "notionalPrincipal": "3112.9970019156",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 3112.9970019156,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-06-01T00:00",
           "eventType": "PR",
-          "payoff": "478.8486779047",
+          "payoff": 478.8486779047,
           "currency": "USD",
-          "notionalPrincipal": "2634.1483240108",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "21.1513220952"
+          "notionalPrincipal": 2634.1483240108,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 21.1513220952
         },
         {
           "eventDate": "2013-06-01T00:00",
           "eventType": "IP",
-          "payoff": "21.1513220952",
+          "payoff": 21.1513220952,
           "currency": "USD",
-          "notionalPrincipal": "2634.1483240108",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 2634.1483240108,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-06-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "2634.1483240108",
-          "nominalInterestRate": "0.1611234567",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 2634.1483240108,
+          "nominalInterestRate": 0.1611234567,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-07-01T00:00",
           "eventType": "PR",
-          "payoff": "465.1159109322",
+          "payoff": 465.1159109322,
           "currency": "USD",
-          "notionalPrincipal": "2169.0324130786",
-          "nominalInterestRate": "0.1611234567",
-          "accruedInterest": "34.8840890677"
+          "notionalPrincipal": 2169.0324130786,
+          "nominalInterestRate": 0.1611234567,
+          "accruedInterest": 34.8840890677
         },
         {
           "eventDate": "2013-07-01T00:00",
           "eventType": "IP",
-          "payoff": "34.8840890677",
+          "payoff": 34.8840890677,
           "currency": "USD",
-          "notionalPrincipal": "2169.0324130786",
-          "nominalInterestRate": "0.1611234567",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 2169.0324130786,
+          "nominalInterestRate": 0.1611234567,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-08-01T00:00",
           "eventType": "PR",
-          "payoff": "470.3179670994",
+          "payoff": 470.3179670994,
           "currency": "USD",
-          "notionalPrincipal": "1698.7144459792",
-          "nominalInterestRate": "0.1611234567",
-          "accruedInterest": "29.6820329005"
+          "notionalPrincipal": 1698.7144459792,
+          "nominalInterestRate": 0.1611234567,
+          "accruedInterest": 29.6820329005
         },
         {
           "eventDate": "2013-08-01T00:00",
           "eventType": "IP",
-          "payoff": "29.6820329005",
+          "payoff": 29.6820329005,
           "currency": "USD",
-          "notionalPrincipal": "1698.7144459792",
-          "nominalInterestRate": "0.1611234567",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 1698.7144459792,
+          "nominalInterestRate": 0.1611234567,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-08-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "1698.7144459792",
-          "nominalInterestRate": "0.1618641975",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 1698.7144459792,
+          "nominalInterestRate": 0.1618641975,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-09-01T00:00",
           "eventType": "PR",
-          "payoff": "476.6471436449",
+          "payoff": 476.6471436449,
           "currency": "USD",
-          "notionalPrincipal": "1222.0673023343",
-          "nominalInterestRate": "0.1618641975",
-          "accruedInterest": "23.352856355"
+          "notionalPrincipal": 1222.0673023343,
+          "nominalInterestRate": 0.1618641975,
+          "accruedInterest": 23.352856355
         },
         {
           "eventDate": "2013-09-01T00:00",
           "eventType": "IP",
-          "payoff": "23.352856355",
+          "payoff": 23.352856355,
           "currency": "USD",
-          "notionalPrincipal": "1222.0673023343",
-          "nominalInterestRate": "0.1618641975",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 1222.0673023343,
+          "nominalInterestRate": 0.1618641975,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-10-01T00:00",
           "eventType": "PR",
-          "payoff": "483.7417306941",
+          "payoff": 483.7417306941,
           "currency": "USD",
-          "notionalPrincipal": "738.3255716401",
-          "nominalInterestRate": "0.1618641975",
-          "accruedInterest": "16.2582693058"
+          "notionalPrincipal": 738.3255716401,
+          "nominalInterestRate": 0.1618641975,
+          "accruedInterest": 16.2582693058
         },
         {
           "eventDate": "2013-10-01T00:00",
           "eventType": "IP",
-          "payoff": "16.2582693058",
+          "payoff": 16.2582693058,
           "currency": "USD",
-          "notionalPrincipal": "738.3255716401",
-          "nominalInterestRate": "0.1618641975",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 738.3255716401,
+          "nominalInterestRate": 0.1618641975,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-10-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "738.3255716401",
-          "nominalInterestRate": "0.1626049382",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 738.3255716401,
+          "nominalInterestRate": 0.1626049382,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-11-01T00:00",
           "eventType": "PR",
-          "payoff": "489.8035153314",
+          "payoff": 489.8035153314,
           "currency": "USD",
-          "notionalPrincipal": "248.5220563087",
-          "nominalInterestRate": "0.1626049382",
-          "accruedInterest": "10.1964846685"
+          "notionalPrincipal": 248.5220563087,
+          "nominalInterestRate": 0.1626049382,
+          "accruedInterest": 10.1964846685
         },
         {
           "eventDate": "2013-11-01T00:00",
           "eventType": "IP",
-          "payoff": "10.1964846685",
+          "payoff": 10.1964846685,
           "currency": "USD",
-          "notionalPrincipal": "248.5220563087",
-          "nominalInterestRate": "0.1626049382",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 248.5220563087,
+          "nominalInterestRate": 0.1626049382,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-12-01T00:00",
           "eventType": "IP",
-          "payoff": "3.3214449554",
+          "payoff": 3.3214449554,
           "currency": "USD",
-          "notionalPrincipal": "248.5220563087",
-          "nominalInterestRate": "0.1626049382",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 248.5220563087,
+          "nominalInterestRate": 0.1626049382,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-12-01T00:00",
           "eventType": "MD",
-          "payoff": "248.5220563087",
+          "payoff": 248.5220563087,
           "currency": "USD",
-          "notionalPrincipal": "0.0",
-          "nominalInterestRate": "0.1626049382",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 0.0,
+          "nominalInterestRate": 0.1626049382,
+          "accruedInterest": 0.0
         }
       ]
     },
@@ -2974,236 +2974,236 @@
         {
           "eventDate": "2013-01-01T00:00",
           "eventType": "IED",
-          "payoff": "-5000.0",
+          "payoff": -5000.0,
           "currency": "USD",
-          "notionalPrincipal": "5000.0",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 5000.0,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-02-01T00:00",
           "eventType": "PR",
-          "payoff": "466.0273972602",
+          "payoff": 466.0273972602,
           "currency": "USD",
-          "notionalPrincipal": "4533.9726027397",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "33.9726027397"
+          "notionalPrincipal": 4533.9726027397,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 33.9726027397
         },
         {
           "eventDate": "2013-02-01T00:00",
           "eventType": "IP",
-          "payoff": "33.9726027397",
+          "payoff": 33.9726027397,
           "currency": "USD",
-          "notionalPrincipal": "4533.9726027397",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4533.9726027397,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-03-01T00:00",
           "eventType": "PR",
-          "payoff": "472.1750722462",
+          "payoff": 472.1750722462,
           "currency": "USD",
-          "notionalPrincipal": "4061.7975304935",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "27.8249277537"
+          "notionalPrincipal": 4061.7975304935,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 27.8249277537
         },
         {
           "eventDate": "2013-03-01T00:00",
           "eventType": "IP",
-          "payoff": "27.8249277537",
+          "payoff": 27.8249277537,
           "currency": "USD",
-          "notionalPrincipal": "4061.7975304935",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4061.7975304935,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-04-01T00:00",
           "eventType": "PR",
-          "payoff": "472.4020332174",
+          "payoff": 472.4020332174,
           "currency": "USD",
-          "notionalPrincipal": "3589.395497276",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "27.5979667825"
+          "notionalPrincipal": 3589.395497276,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 27.5979667825
         },
         {
           "eventDate": "2013-04-01T00:00",
           "eventType": "IP",
-          "payoff": "27.5979667825",
+          "payoff": 27.5979667825,
           "currency": "USD",
-          "notionalPrincipal": "3589.395497276",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 3589.395497276,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-04-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "3589.395497276",
-          "nominalInterestRate": "-0.0394320988",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 3589.395497276,
+          "nominalInterestRate": -0.0394320988,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-05-01T00:00",
           "eventType": "PR",
-          "payoff": "511.6332107751",
+          "payoff": 511.6332107751,
           "currency": "USD",
-          "notionalPrincipal": "3077.7622865008",
-          "nominalInterestRate": "-0.0394320988",
-          "accruedInterest": "-11.6332107752"
+          "notionalPrincipal": 3077.7622865008,
+          "nominalInterestRate": -0.0394320988,
+          "accruedInterest": -11.6332107752
         },
         {
           "eventDate": "2013-05-01T00:00",
           "eventType": "IP",
-          "payoff": "-11.6332107752",
+          "payoff": -11.6332107752,
           "currency": "USD",
-          "notionalPrincipal": "3077.7622865008",
-          "nominalInterestRate": "-0.0394320988",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 3077.7622865008,
+          "nominalInterestRate": -0.0394320988,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-06-01T00:00",
           "eventType": "PR",
-          "payoff": "510.3075107408",
+          "payoff": 510.3075107408,
           "currency": "USD",
-          "notionalPrincipal": "2567.45477576",
-          "nominalInterestRate": "-0.0394320988",
-          "accruedInterest": "-10.3075107409"
+          "notionalPrincipal": 2567.45477576,
+          "nominalInterestRate": -0.0394320988,
+          "accruedInterest": -10.3075107409
         },
         {
           "eventDate": "2013-06-01T00:00",
           "eventType": "IP",
-          "payoff": "-10.3075107409",
+          "payoff": -10.3075107409,
           "currency": "USD",
-          "notionalPrincipal": "2567.45477576",
-          "nominalInterestRate": "-0.0394320988",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 2567.45477576,
+          "nominalInterestRate": -0.0394320988,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-07-01T00:00",
           "eventType": "PR",
-          "payoff": "508.3211065999",
+          "payoff": 508.3211065999,
           "currency": "USD",
-          "notionalPrincipal": "2059.1336691601",
-          "nominalInterestRate": "-0.0394320988",
-          "accruedInterest": "-8.3211066"
+          "notionalPrincipal": 2059.1336691601,
+          "nominalInterestRate": -0.0394320988,
+          "accruedInterest": -8.3211066
         },
         {
           "eventDate": "2013-07-01T00:00",
           "eventType": "IP",
-          "payoff": "-8.3211066",
+          "payoff": -8.3211066,
           "currency": "USD",
-          "notionalPrincipal": "2059.1336691601",
-          "nominalInterestRate": "-0.0394320988",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 2059.1336691601,
+          "nominalInterestRate": -0.0394320988,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-07-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "2059.1336691601",
-          "nominalInterestRate": "-0.0383209877",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 2059.1336691601,
+          "nominalInterestRate": -0.0383209877,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-08-01T00:00",
           "eventType": "PR",
-          "payoff": "506.7017783927",
+          "payoff": 506.7017783927,
           "currency": "USD",
-          "notionalPrincipal": "1552.4318907673",
-          "nominalInterestRate": "-0.0383209877",
-          "accruedInterest": "-6.7017783928"
+          "notionalPrincipal": 1552.4318907673,
+          "nominalInterestRate": -0.0383209877,
+          "accruedInterest": -6.7017783928
         },
         {
           "eventDate": "2013-08-01T00:00",
           "eventType": "IP",
-          "payoff": "-6.7017783928",
+          "payoff": -6.7017783928,
           "currency": "USD",
-          "notionalPrincipal": "1552.4318907673",
-          "nominalInterestRate": "-0.0383209877",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 1552.4318907673,
+          "nominalInterestRate": -0.0383209877,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-09-01T00:00",
           "eventType": "PR",
-          "payoff": "505.0526367751",
+          "payoff": 505.0526367751,
           "currency": "USD",
-          "notionalPrincipal": "1047.3792539922",
-          "nominalInterestRate": "-0.0383209877",
-          "accruedInterest": "-5.0526367752"
+          "notionalPrincipal": 1047.3792539922,
+          "nominalInterestRate": -0.0383209877,
+          "accruedInterest": -5.0526367752
         },
         {
           "eventDate": "2013-09-01T00:00",
           "eventType": "IP",
-          "payoff": "-5.0526367752",
+          "payoff": -5.0526367752,
           "currency": "USD",
-          "notionalPrincipal": "1047.3792539922",
-          "nominalInterestRate": "-0.0383209877",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 1047.3792539922,
+          "nominalInterestRate": -0.0383209877,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-10-01T00:00",
           "eventType": "PR",
-          "payoff": "503.2988992434",
+          "payoff": 503.2988992434,
           "currency": "USD",
-          "notionalPrincipal": "544.0803547487",
-          "nominalInterestRate": "-0.0383209877",
-          "accruedInterest": "-3.2988992435"
+          "notionalPrincipal": 544.0803547487,
+          "nominalInterestRate": -0.0383209877,
+          "accruedInterest": -3.2988992435
         },
         {
           "eventDate": "2013-10-01T00:00",
           "eventType": "IP",
-          "payoff": "-3.2988992435",
+          "payoff": -3.2988992435,
           "currency": "USD",
-          "notionalPrincipal": "544.0803547487",
-          "nominalInterestRate": "-0.0383209877",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 544.0803547487,
+          "nominalInterestRate": -0.0383209877,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-10-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "544.0803547487",
-          "nominalInterestRate": "-0.0372098766",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 544.0803547487,
+          "nominalInterestRate": -0.0372098766,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-11-01T00:00",
           "eventType": "PR",
-          "payoff": "501.7194521855",
+          "payoff": 501.7194521855,
           "currency": "USD",
-          "notionalPrincipal": "42.3609025632",
-          "nominalInterestRate": "-0.0372098766",
-          "accruedInterest": "-1.7194521856"
+          "notionalPrincipal": 42.3609025632,
+          "nominalInterestRate": -0.0372098766,
+          "accruedInterest": -1.7194521856
         },
         {
           "eventDate": "2013-11-01T00:00",
           "eventType": "IP",
-          "payoff": "-1.7194521856",
+          "payoff": -1.7194521856,
           "currency": "USD",
-          "notionalPrincipal": "42.3609025632",
-          "nominalInterestRate": "-0.0372098766",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 42.3609025632,
+          "nominalInterestRate": -0.0372098766,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-12-01T00:00",
           "eventType": "IP",
-          "payoff": "-0.1295542977",
+          "payoff": -0.1295542977,
           "currency": "USD",
-          "notionalPrincipal": "42.3609025632",
-          "nominalInterestRate": "-0.0372098766",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 42.3609025632,
+          "nominalInterestRate": -0.0372098766,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-12-01T00:00",
           "eventType": "MD",
-          "payoff": "42.3609025632",
+          "payoff": 42.3609025632,
           "currency": "USD",
-          "notionalPrincipal": "0.0",
-          "nominalInterestRate": "-0.0372098766",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 0.0,
+          "nominalInterestRate": -0.0372098766,
+          "accruedInterest": 0.0
         }
       ]
     },
@@ -3290,236 +3290,236 @@
         {
           "eventDate": "2013-01-01T00:00",
           "eventType": "IED",
-          "payoff": "-5000.0",
+          "payoff": -5000.0,
           "currency": "USD",
-          "notionalPrincipal": "5000.0",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 5000.0,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-02-01T00:00",
           "eventType": "PR",
-          "payoff": "466.0273972602",
+          "payoff": 466.0273972602,
           "currency": "USD",
-          "notionalPrincipal": "4533.9726027397",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "33.9726027397"
+          "notionalPrincipal": 4533.9726027397,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 33.9726027397
         },
         {
           "eventDate": "2013-02-01T00:00",
           "eventType": "IP",
-          "payoff": "33.9726027397",
+          "payoff": 33.9726027397,
           "currency": "USD",
-          "notionalPrincipal": "4533.9726027397",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4533.9726027397,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-03-01T00:00",
           "eventType": "PR",
-          "payoff": "472.1750722462",
+          "payoff": 472.1750722462,
           "currency": "USD",
-          "notionalPrincipal": "4061.7975304935",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "27.8249277537"
+          "notionalPrincipal": 4061.7975304935,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 27.8249277537
         },
         {
           "eventDate": "2013-03-01T00:00",
           "eventType": "IP",
-          "payoff": "27.8249277537",
+          "payoff": 27.8249277537,
           "currency": "USD",
-          "notionalPrincipal": "4061.7975304935",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4061.7975304935,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-04-01T00:00",
           "eventType": "PR",
-          "payoff": "472.4020332174",
+          "payoff": 472.4020332174,
           "currency": "USD",
-          "notionalPrincipal": "3589.395497276",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "27.5979667825"
+          "notionalPrincipal": 3589.395497276,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 27.5979667825
         },
         {
           "eventDate": "2013-04-01T00:00",
           "eventType": "IP",
-          "payoff": "27.5979667825",
+          "payoff": 27.5979667825,
           "currency": "USD",
-          "notionalPrincipal": "3589.395497276",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 3589.395497276,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-04-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "3589.395497276",
-          "nominalInterestRate": "0.1166790123",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 3589.395497276,
+          "nominalInterestRate": 0.1166790123,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-05-01T00:00",
           "eventType": "PR",
-          "payoff": "465.5774968597",
+          "payoff": 465.5774968597,
           "currency": "USD",
-          "notionalPrincipal": "3123.8180004162",
-          "nominalInterestRate": "0.1166790123",
-          "accruedInterest": "34.4225031402"
+          "notionalPrincipal": 3123.8180004162,
+          "nominalInterestRate": 0.1166790123,
+          "accruedInterest": 34.4225031402
         },
         {
           "eventDate": "2013-05-01T00:00",
           "eventType": "IP",
-          "payoff": "34.4225031402",
+          "payoff": 34.4225031402,
           "currency": "USD",
-          "notionalPrincipal": "3123.8180004162",
-          "nominalInterestRate": "0.1166790123",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 3123.8180004162,
+          "nominalInterestRate": 0.1166790123,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-06-01T00:00",
           "eventType": "PR",
-          "payoff": "469.0438247394",
+          "payoff": 469.0438247394,
           "currency": "USD",
-          "notionalPrincipal": "2654.7741756768",
-          "nominalInterestRate": "0.1166790123",
-          "accruedInterest": "30.9561752605"
+          "notionalPrincipal": 2654.7741756768,
+          "nominalInterestRate": 0.1166790123,
+          "accruedInterest": 30.9561752605
         },
         {
           "eventDate": "2013-06-01T00:00",
           "eventType": "IP",
-          "payoff": "30.9561752605",
+          "payoff": 30.9561752605,
           "currency": "USD",
-          "notionalPrincipal": "2654.7741756768",
-          "nominalInterestRate": "0.1166790123",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 2654.7741756768,
+          "nominalInterestRate": 0.1166790123,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-07-01T00:00",
           "eventType": "PR",
-          "payoff": "474.5405674943",
+          "payoff": 474.5405674943,
           "currency": "USD",
-          "notionalPrincipal": "2180.2336081824",
-          "nominalInterestRate": "0.1166790123",
-          "accruedInterest": "25.4594325056"
+          "notionalPrincipal": 2180.2336081824,
+          "nominalInterestRate": 0.1166790123,
+          "accruedInterest": 25.4594325056
         },
         {
           "eventDate": "2013-07-01T00:00",
           "eventType": "IP",
-          "payoff": "25.4594325056",
+          "payoff": 25.4594325056,
           "currency": "USD",
-          "notionalPrincipal": "2180.2336081824",
-          "nominalInterestRate": "0.1166790123",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 2180.2336081824,
+          "nominalInterestRate": 0.1166790123,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-07-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "2180.2336081824",
-          "nominalInterestRate": "0.1177901234",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 2180.2336081824,
+          "nominalInterestRate": 0.1177901234,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-08-01T00:00",
           "eventType": "PR",
-          "payoff": "478.1887409259",
+          "payoff": 478.1887409259,
           "currency": "USD",
-          "notionalPrincipal": "1702.0448672565",
-          "nominalInterestRate": "0.1177901234",
-          "accruedInterest": "21.811259074"
+          "notionalPrincipal": 1702.0448672565,
+          "nominalInterestRate": 0.1177901234,
+          "accruedInterest": 21.811259074
         },
         {
           "eventDate": "2013-08-01T00:00",
           "eventType": "IP",
-          "payoff": "21.811259074",
+          "payoff": 21.811259074,
           "currency": "USD",
-          "notionalPrincipal": "1702.0448672565",
-          "nominalInterestRate": "0.1177901234",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 1702.0448672565,
+          "nominalInterestRate": 0.1177901234,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-09-01T00:00",
           "eventType": "PR",
-          "payoff": "482.9725854072",
+          "payoff": 482.9725854072,
           "currency": "USD",
-          "notionalPrincipal": "1219.0722818492",
-          "nominalInterestRate": "0.1177901234",
-          "accruedInterest": "17.0274145927"
+          "notionalPrincipal": 1219.0722818492,
+          "nominalInterestRate": 0.1177901234,
+          "accruedInterest": 17.0274145927
         },
         {
           "eventDate": "2013-09-01T00:00",
           "eventType": "IP",
-          "payoff": "17.0274145927",
+          "payoff": 17.0274145927,
           "currency": "USD",
-          "notionalPrincipal": "1219.0722818492",
-          "nominalInterestRate": "0.1177901234",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 1219.0722818492,
+          "nominalInterestRate": 0.1177901234,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-10-01T00:00",
           "eventType": "PR",
-          "payoff": "488.1976979795",
+          "payoff": 488.1976979795,
           "currency": "USD",
-          "notionalPrincipal": "730.8745838696",
-          "nominalInterestRate": "0.1177901234",
-          "accruedInterest": "11.8023020204"
+          "notionalPrincipal": 730.8745838696,
+          "nominalInterestRate": 0.1177901234,
+          "accruedInterest": 11.8023020204
         },
         {
           "eventDate": "2013-10-01T00:00",
           "eventType": "IP",
-          "payoff": "11.8023020204",
+          "payoff": 11.8023020204,
           "currency": "USD",
-          "notionalPrincipal": "730.8745838696",
-          "nominalInterestRate": "0.1177901234",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 730.8745838696,
+          "nominalInterestRate": 0.1177901234,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-10-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "730.8745838696",
-          "nominalInterestRate": "0.1189012345",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 730.8745838696,
+          "nominalInterestRate": 0.1189012345,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-11-01T00:00",
           "eventType": "PR",
-          "payoff": "492.6192915056",
+          "payoff": 492.6192915056,
           "currency": "USD",
-          "notionalPrincipal": "238.255292364",
-          "nominalInterestRate": "0.1189012345",
-          "accruedInterest": "7.3807084943"
+          "notionalPrincipal": 238.255292364,
+          "nominalInterestRate": 0.1189012345,
+          "accruedInterest": 7.3807084943
         },
         {
           "eventDate": "2013-11-01T00:00",
           "eventType": "IP",
-          "payoff": "7.3807084943",
+          "payoff": 7.3807084943,
           "currency": "USD",
-          "notionalPrincipal": "238.255292364",
-          "nominalInterestRate": "0.1189012345",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 238.255292364,
+          "nominalInterestRate": 0.1189012345,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-12-01T00:00",
           "eventType": "IP",
-          "payoff": "2.3283984989",
+          "payoff": 2.3283984989,
           "currency": "USD",
-          "notionalPrincipal": "238.255292364",
-          "nominalInterestRate": "0.1189012345",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 238.255292364,
+          "nominalInterestRate": 0.1189012345,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-12-01T00:00",
           "eventType": "MD",
-          "payoff": "238.255292364",
+          "payoff": 238.255292364,
           "currency": "USD",
-          "notionalPrincipal": "0.0",
-          "nominalInterestRate": "0.1189012345",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 0.0,
+          "nominalInterestRate": 0.1189012345,
+          "accruedInterest": 0.0
         }
       ]
     },
@@ -3607,236 +3607,236 @@
         {
           "eventDate": "2013-01-01T00:00",
           "eventType": "IED",
-          "payoff": "-5000.0",
+          "payoff": -5000.0,
           "currency": "USD",
-          "notionalPrincipal": "5000.0",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 5000.0,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-02-01T00:00",
           "eventType": "PR",
-          "payoff": "466.0273972602",
+          "payoff": 466.0273972602,
           "currency": "USD",
-          "notionalPrincipal": "4533.9726027397",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "33.9726027397"
+          "notionalPrincipal": 4533.9726027397,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 33.9726027397
         },
         {
           "eventDate": "2013-02-01T00:00",
           "eventType": "IP",
-          "payoff": "33.9726027397",
+          "payoff": 33.9726027397,
           "currency": "USD",
-          "notionalPrincipal": "4533.9726027397",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4533.9726027397,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-03-01T00:00",
           "eventType": "PR",
-          "payoff": "472.1750722462",
+          "payoff": 472.1750722462,
           "currency": "USD",
-          "notionalPrincipal": "4061.7975304935",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "27.8249277537"
+          "notionalPrincipal": 4061.7975304935,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 27.8249277537
         },
         {
           "eventDate": "2013-03-01T00:00",
           "eventType": "IP",
-          "payoff": "27.8249277537",
+          "payoff": 27.8249277537,
           "currency": "USD",
-          "notionalPrincipal": "4061.7975304935",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4061.7975304935,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-04-01T00:00",
           "eventType": "PR",
-          "payoff": "472.4020332174",
+          "payoff": 472.4020332174,
           "currency": "USD",
-          "notionalPrincipal": "3589.395497276",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "27.5979667825"
+          "notionalPrincipal": 3589.395497276,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 27.5979667825
         },
         {
           "eventDate": "2013-04-01T00:00",
           "eventType": "IP",
-          "payoff": "27.5979667825",
+          "payoff": 27.5979667825,
           "currency": "USD",
-          "notionalPrincipal": "3589.395497276",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 3589.395497276,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-04-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "3589.395497276",
-          "nominalInterestRate": "0.1158518518",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 3589.395497276,
+          "nominalInterestRate": 0.1158518518,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-05-01T00:00",
           "eventType": "PR",
-          "payoff": "465.8215247636",
+          "payoff": 465.8215247636,
           "currency": "USD",
-          "notionalPrincipal": "3123.5739725124",
-          "nominalInterestRate": "0.1158518518",
-          "accruedInterest": "34.1784752363"
+          "notionalPrincipal": 3123.5739725124,
+          "nominalInterestRate": 0.1158518518,
+          "accruedInterest": 34.1784752363
         },
         {
           "eventDate": "2013-05-01T00:00",
           "eventType": "IP",
-          "payoff": "34.1784752363",
+          "payoff": 34.1784752363,
           "currency": "USD",
-          "notionalPrincipal": "3123.5739725124",
-          "nominalInterestRate": "0.1158518518",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 3123.5739725124,
+          "nominalInterestRate": 0.1158518518,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-06-01T00:00",
           "eventType": "PR",
-          "payoff": "469.265680268",
+          "payoff": 469.265680268,
           "currency": "USD",
-          "notionalPrincipal": "2654.3082922443",
-          "nominalInterestRate": "0.1158518518",
-          "accruedInterest": "30.7343197319"
+          "notionalPrincipal": 2654.3082922443,
+          "nominalInterestRate": 0.1158518518,
+          "accruedInterest": 30.7343197319
         },
         {
           "eventDate": "2013-06-01T00:00",
           "eventType": "IP",
-          "payoff": "30.7343197319",
+          "payoff": 30.7343197319,
           "currency": "USD",
-          "notionalPrincipal": "2654.3082922443",
-          "nominalInterestRate": "0.1158518518",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 2654.3082922443,
+          "nominalInterestRate": 0.1158518518,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-07-01T00:00",
           "eventType": "PR",
-          "payoff": "474.7254905999",
+          "payoff": 474.7254905999,
           "currency": "USD",
-          "notionalPrincipal": "2179.5828016443",
-          "nominalInterestRate": "0.1158518518",
-          "accruedInterest": "25.2745094"
+          "notionalPrincipal": 2179.5828016443,
+          "nominalInterestRate": 0.1158518518,
+          "accruedInterest": 25.2745094
         },
         {
           "eventDate": "2013-07-01T00:00",
           "eventType": "IP",
-          "payoff": "25.2745094",
+          "payoff": 25.2745094,
           "currency": "USD",
-          "notionalPrincipal": "2179.5828016443",
-          "nominalInterestRate": "0.1158518518",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 2179.5828016443,
+          "nominalInterestRate": 0.1158518518,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-07-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "2179.5828016443",
-          "nominalInterestRate": "0.1175185185",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 2179.5828016443,
+          "nominalInterestRate": 0.1175185185,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-08-01T00:00",
           "eventType": "PR",
-          "payoff": "478.2455298713",
+          "payoff": 478.2455298713,
           "currency": "USD",
-          "notionalPrincipal": "1701.337271773",
-          "nominalInterestRate": "0.1175185185",
-          "accruedInterest": "21.7544701286"
+          "notionalPrincipal": 1701.337271773,
+          "nominalInterestRate": 0.1175185185,
+          "accruedInterest": 21.7544701286
         },
         {
           "eventDate": "2013-08-01T00:00",
           "eventType": "IP",
-          "payoff": "21.7544701286",
+          "payoff": 21.7544701286,
           "currency": "USD",
-          "notionalPrincipal": "1701.337271773",
-          "nominalInterestRate": "0.1175185185",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 1701.337271773,
+          "nominalInterestRate": 0.1175185185,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-09-01T00:00",
           "eventType": "PR",
-          "payoff": "483.0189103943",
+          "payoff": 483.0189103943,
           "currency": "USD",
-          "notionalPrincipal": "1218.3183613786",
-          "nominalInterestRate": "0.1175185185",
-          "accruedInterest": "16.9810896056"
+          "notionalPrincipal": 1218.3183613786,
+          "nominalInterestRate": 0.1175185185,
+          "accruedInterest": 16.9810896056
         },
         {
           "eventDate": "2013-09-01T00:00",
           "eventType": "IP",
-          "payoff": "16.9810896056",
+          "payoff": 16.9810896056,
           "currency": "USD",
-          "notionalPrincipal": "1218.3183613786",
-          "nominalInterestRate": "0.1175185185",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 1218.3183613786,
+          "nominalInterestRate": 0.1175185185,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-10-01T00:00",
           "eventType": "PR",
-          "payoff": "488.2321943359",
+          "payoff": 488.2321943359,
           "currency": "USD",
-          "notionalPrincipal": "730.0861670427",
-          "nominalInterestRate": "0.1175185185",
-          "accruedInterest": "11.767805664"
+          "notionalPrincipal": 730.0861670427,
+          "nominalInterestRate": 0.1175185185,
+          "accruedInterest": 11.767805664
         },
         {
           "eventDate": "2013-10-01T00:00",
           "eventType": "IP",
-          "payoff": "11.767805664",
+          "payoff": 11.767805664,
           "currency": "USD",
-          "notionalPrincipal": "730.0861670427",
-          "nominalInterestRate": "0.1175185185",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 730.0861670427,
+          "nominalInterestRate": 0.1175185185,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-10-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "730.0861670427",
-          "nominalInterestRate": "0.1191851851",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 730.0861670427,
+          "nominalInterestRate": 0.1191851851,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-11-01T00:00",
           "eventType": "PR",
-          "payoff": "492.6096462859",
+          "payoff": 492.6096462859,
           "currency": "USD",
-          "notionalPrincipal": "237.4765207567",
-          "nominalInterestRate": "0.1191851851",
-          "accruedInterest": "7.390353714"
+          "notionalPrincipal": 237.4765207567,
+          "nominalInterestRate": 0.1191851851,
+          "accruedInterest": 7.390353714
         },
         {
           "eventDate": "2013-11-01T00:00",
           "eventType": "IP",
-          "payoff": "7.390353714",
+          "payoff": 7.390353714,
           "currency": "USD",
-          "notionalPrincipal": "237.4765207567",
-          "nominalInterestRate": "0.1191851851",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 237.4765207567,
+          "nominalInterestRate": 0.1191851851,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-12-01T00:00",
           "eventType": "IP",
-          "payoff": "2.326330118",
+          "payoff": 2.326330118,
           "currency": "USD",
-          "notionalPrincipal": "237.4765207567",
-          "nominalInterestRate": "0.1191851851",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 237.4765207567,
+          "nominalInterestRate": 0.1191851851,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-12-01T00:00",
           "eventType": "MD",
-          "payoff": "237.4765207567",
+          "payoff": 237.4765207567,
           "currency": "USD",
-          "notionalPrincipal": "0.0",
-          "nominalInterestRate": "0.1191851851",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 0.0,
+          "nominalInterestRate": 0.1191851851,
+          "accruedInterest": 0.0
         }
       ]
     },
@@ -3924,236 +3924,236 @@
         {
           "eventDate": "2013-01-01T00:00",
           "eventType": "IED",
-          "payoff": "-5000.0",
+          "payoff": -5000.0,
           "currency": "USD",
-          "notionalPrincipal": "5000.0",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 5000.0,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-02-01T00:00",
           "eventType": "PR",
-          "payoff": "466.0273972602",
+          "payoff": 466.0273972602,
           "currency": "USD",
-          "notionalPrincipal": "4533.9726027397",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "33.9726027397"
+          "notionalPrincipal": 4533.9726027397,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 33.9726027397
         },
         {
           "eventDate": "2013-02-01T00:00",
           "eventType": "IP",
-          "payoff": "33.9726027397",
+          "payoff": 33.9726027397,
           "currency": "USD",
-          "notionalPrincipal": "4533.9726027397",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4533.9726027397,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-03-01T00:00",
           "eventType": "PR",
-          "payoff": "472.1750722462",
+          "payoff": 472.1750722462,
           "currency": "USD",
-          "notionalPrincipal": "4061.7975304935",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "27.8249277537"
+          "notionalPrincipal": 4061.7975304935,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 27.8249277537
         },
         {
           "eventDate": "2013-03-01T00:00",
           "eventType": "IP",
-          "payoff": "27.8249277537",
+          "payoff": 27.8249277537,
           "currency": "USD",
-          "notionalPrincipal": "4061.7975304935",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4061.7975304935,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-04-01T00:00",
           "eventType": "PR",
-          "payoff": "472.4020332174",
+          "payoff": 472.4020332174,
           "currency": "USD",
-          "notionalPrincipal": "3589.395497276",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "27.5979667825"
+          "notionalPrincipal": 3589.395497276,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 27.5979667825
         },
         {
           "eventDate": "2013-04-01T00:00",
           "eventType": "IP",
-          "payoff": "27.5979667825",
+          "payoff": 27.5979667825,
           "currency": "USD",
-          "notionalPrincipal": "3589.395497276",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 3589.395497276,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-04-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "3589.395497276",
-          "nominalInterestRate": "0.0894320987",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 3589.395497276,
+          "nominalInterestRate": 0.0894320987,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-05-01T00:00",
           "eventType": "PR",
-          "payoff": "473.6158488257",
+          "payoff": 473.6158488257,
           "currency": "USD",
-          "notionalPrincipal": "3115.7796484503",
-          "nominalInterestRate": "0.0894320987",
-          "accruedInterest": "26.3841511742"
+          "notionalPrincipal": 3115.7796484503,
+          "nominalInterestRate": 0.0894320987,
+          "accruedInterest": 26.3841511742
         },
         {
           "eventDate": "2013-05-01T00:00",
           "eventType": "IP",
-          "payoff": "26.3841511742",
+          "payoff": 26.3841511742,
           "currency": "USD",
-          "notionalPrincipal": "3115.7796484503",
-          "nominalInterestRate": "0.0894320987",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 3115.7796484503,
+          "nominalInterestRate": 0.0894320987,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-06-01T00:00",
           "eventType": "PR",
-          "payoff": "476.3337750389",
+          "payoff": 476.3337750389,
           "currency": "USD",
-          "notionalPrincipal": "2639.4458734114",
-          "nominalInterestRate": "0.0894320987",
-          "accruedInterest": "23.666224961"
+          "notionalPrincipal": 2639.4458734114,
+          "nominalInterestRate": 0.0894320987,
+          "accruedInterest": 23.666224961
         },
         {
           "eventDate": "2013-06-01T00:00",
           "eventType": "IP",
-          "payoff": "23.666224961",
+          "payoff": 23.666224961,
           "currency": "USD",
-          "notionalPrincipal": "2639.4458734114",
-          "nominalInterestRate": "0.0894320987",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 2639.4458734114,
+          "nominalInterestRate": 0.0894320987,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-07-01T00:00",
           "eventType": "PR",
-          "payoff": "480.5985328188",
+          "payoff": 480.5985328188,
           "currency": "USD",
-          "notionalPrincipal": "2158.8473405925",
-          "nominalInterestRate": "0.0894320987",
-          "accruedInterest": "19.4014671811"
+          "notionalPrincipal": 2158.8473405925,
+          "nominalInterestRate": 0.0894320987,
+          "accruedInterest": 19.4014671811
         },
         {
           "eventDate": "2013-07-01T00:00",
           "eventType": "IP",
-          "payoff": "19.4014671811",
+          "payoff": 19.4014671811,
           "currency": "USD",
-          "notionalPrincipal": "2158.8473405925",
-          "nominalInterestRate": "0.0894320987",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 2158.8473405925,
+          "nominalInterestRate": 0.0894320987,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-07-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "2158.8473405925",
-          "nominalInterestRate": "0.0883209876",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 2158.8473405925,
+          "nominalInterestRate": 0.0883209876,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-08-01T00:00",
           "eventType": "PR",
-          "payoff": "483.8059797019",
+          "payoff": 483.8059797019,
           "currency": "USD",
-          "notionalPrincipal": "1675.0413608906",
-          "nominalInterestRate": "0.0883209876",
-          "accruedInterest": "16.194020298"
+          "notionalPrincipal": 1675.0413608906,
+          "nominalInterestRate": 0.0883209876,
+          "accruedInterest": 16.194020298
         },
         {
           "eventDate": "2013-08-01T00:00",
           "eventType": "IP",
-          "payoff": "16.194020298",
+          "payoff": 16.194020298,
           "currency": "USD",
-          "notionalPrincipal": "1675.0413608906",
-          "nominalInterestRate": "0.0883209876",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 1675.0413608906,
+          "nominalInterestRate": 0.0883209876,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-09-01T00:00",
           "eventType": "PR",
-          "payoff": "487.435121841",
+          "payoff": 487.435121841,
           "currency": "USD",
-          "notionalPrincipal": "1187.6062390496",
-          "nominalInterestRate": "0.0883209876",
-          "accruedInterest": "12.5648781589"
+          "notionalPrincipal": 1187.6062390496,
+          "nominalInterestRate": 0.0883209876,
+          "accruedInterest": 12.5648781589
         },
         {
           "eventDate": "2013-09-01T00:00",
           "eventType": "IP",
-          "payoff": "12.5648781589",
+          "payoff": 12.5648781589,
           "currency": "USD",
-          "notionalPrincipal": "1187.6062390496",
-          "nominalInterestRate": "0.0883209876",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 1187.6062390496,
+          "nominalInterestRate": 0.0883209876,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-10-01T00:00",
           "eventType": "PR",
-          "payoff": "491.3788584128",
+          "payoff": 491.3788584128,
           "currency": "USD",
-          "notionalPrincipal": "696.2273806367",
-          "nominalInterestRate": "0.0883209876",
-          "accruedInterest": "8.6211415871"
+          "notionalPrincipal": 696.2273806367,
+          "nominalInterestRate": 0.0883209876,
+          "accruedInterest": 8.6211415871
         },
         {
           "eventDate": "2013-10-01T00:00",
           "eventType": "IP",
-          "payoff": "8.6211415871",
+          "payoff": 8.6211415871,
           "currency": "USD",
-          "notionalPrincipal": "696.2273806367",
-          "nominalInterestRate": "0.0883209876",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 696.2273806367,
+          "nominalInterestRate": 0.0883209876,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-10-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "696.2273806367",
-          "nominalInterestRate": "0.0872098765",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 696.2273806367,
+          "nominalInterestRate": 0.0872098765,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-11-01T00:00",
           "eventType": "PR",
-          "payoff": "494.843136928",
+          "payoff": 494.843136928,
           "currency": "USD",
-          "notionalPrincipal": "201.3842437087",
-          "nominalInterestRate": "0.0872098765",
-          "accruedInterest": "5.1568630719"
+          "notionalPrincipal": 201.3842437087,
+          "nominalInterestRate": 0.0872098765,
+          "accruedInterest": 5.1568630719
         },
         {
           "eventDate": "2013-11-01T00:00",
           "eventType": "IP",
-          "payoff": "5.1568630719",
+          "payoff": 5.1568630719,
           "currency": "USD",
-          "notionalPrincipal": "201.3842437087",
-          "nominalInterestRate": "0.0872098765",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 201.3842437087,
+          "nominalInterestRate": 0.0872098765,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-12-01T00:00",
           "eventType": "IP",
-          "payoff": "1.4435091806",
+          "payoff": 1.4435091806,
           "currency": "USD",
-          "notionalPrincipal": "201.3842437087",
-          "nominalInterestRate": "0.0872098765",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 201.3842437087,
+          "nominalInterestRate": 0.0872098765,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-12-01T00:00",
           "eventType": "MD",
-          "payoff": "201.3842437087",
+          "payoff": 201.3842437087,
           "currency": "USD",
-          "notionalPrincipal": "0.0",
-          "nominalInterestRate": "0.0872098765",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 0.0,
+          "nominalInterestRate": 0.0872098765,
+          "accruedInterest": 0.0
         }
       ]
     },
@@ -4493,218 +4493,218 @@
         {
           "eventDate": "2013-01-01T00:00",
           "eventType": "IED",
-          "payoff": "-5000.0",
+          "payoff": -5000.0,
           "currency": "USD",
-          "notionalPrincipal": "5000.0",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 5000.0,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-02-01T00:00",
           "eventType": "PR",
-          "payoff": "416.0273972602",
+          "payoff": 416.0273972602,
           "currency": "USD",
-          "notionalPrincipal": "4583.9726027397",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "33.9726027397"
+          "notionalPrincipal": 4583.9726027397,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 33.9726027397
         },
         {
           "eventDate": "2013-02-01T00:00",
           "eventType": "IP",
-          "payoff": "33.9726027397",
+          "payoff": 33.9726027397,
           "currency": "USD",
-          "notionalPrincipal": "4583.9726027397",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4583.9726027397,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-03-01T00:00",
           "eventType": "PR",
-          "payoff": "421.8682229311",
+          "payoff": 421.8682229311,
           "currency": "USD",
-          "notionalPrincipal": "4162.1043798085",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "28.1317770688"
+          "notionalPrincipal": 4162.1043798085,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 28.1317770688
         },
         {
           "eventDate": "2013-03-01T00:00",
           "eventType": "IP",
-          "payoff": "28.1317770688",
+          "payoff": 28.1317770688,
           "currency": "USD",
-          "notionalPrincipal": "4162.1043798085",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4162.1043798085,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-04-01T00:00",
           "eventType": "PR",
-          "payoff": "421.7204962686",
+          "payoff": 421.7204962686,
           "currency": "USD",
-          "notionalPrincipal": "3740.3838835398",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "28.2795037313"
+          "notionalPrincipal": 3740.3838835398,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 28.2795037313
         },
         {
           "eventDate": "2013-04-01T00:00",
           "eventType": "IP",
-          "payoff": "28.2795037313",
+          "payoff": 28.2795037313,
           "currency": "USD",
-          "notionalPrincipal": "3740.3838835398",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 3740.3838835398,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-04-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "3740.3838835398",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 3740.3838835398,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-05-01T00:00",
           "eventType": "PR",
-          "payoff": "416.0082414398",
+          "payoff": 416.0082414398,
           "currency": "USD",
-          "notionalPrincipal": "3324.3756421",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "33.9917585601"
+          "notionalPrincipal": 3324.3756421,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 33.9917585601
         },
         {
           "eventDate": "2013-05-01T00:00",
           "eventType": "IP",
-          "payoff": "33.9917585601",
+          "payoff": 33.9917585601,
           "currency": "USD",
-          "notionalPrincipal": "3324.3756421",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 3324.3756421,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-06-01T00:00",
           "eventType": "PR",
-          "payoff": "418.7817907738",
+          "payoff": 418.7817907738,
           "currency": "USD",
-          "notionalPrincipal": "2905.5938513261",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "31.2182092261"
+          "notionalPrincipal": 2905.5938513261,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 31.2182092261
         },
         {
           "eventDate": "2013-06-01T00:00",
           "eventType": "IP",
-          "payoff": "31.2182092261",
+          "payoff": 31.2182092261,
           "currency": "USD",
-          "notionalPrincipal": "2905.5938513261",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 2905.5938513261,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-07-01T00:00",
           "eventType": "PR",
-          "payoff": "423.5946235083",
+          "payoff": 423.5946235083,
           "currency": "USD",
-          "notionalPrincipal": "2481.9992278177",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "26.4053764916"
+          "notionalPrincipal": 2481.9992278177,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 26.4053764916
         },
         {
           "eventDate": "2013-07-01T00:00",
           "eventType": "IP",
-          "payoff": "26.4053764916",
+          "payoff": 26.4053764916,
           "currency": "USD",
-          "notionalPrincipal": "2481.9992278177",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 2481.9992278177,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-07-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "2481.9992278177",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 2481.9992278177,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-08-01T00:00",
           "eventType": "PR",
-          "payoff": "426.4580715217",
+          "payoff": 426.4580715217,
           "currency": "USD",
-          "notionalPrincipal": "2055.5411562959",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "23.5419284782"
+          "notionalPrincipal": 2055.5411562959,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": 23.5419284782
         },
         {
           "eventDate": "2013-08-01T00:00",
           "eventType": "IP",
-          "payoff": "23.5419284782",
+          "payoff": 23.5419284782,
           "currency": "USD",
-          "notionalPrincipal": "2055.5411562959",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 2055.5411562959,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-09-01T00:00",
           "eventType": "PR",
-          "payoff": "430.5030548183",
+          "payoff": 430.5030548183,
           "currency": "USD",
-          "notionalPrincipal": "1625.0381014776",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "19.4969451816"
+          "notionalPrincipal": 1625.0381014776,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": 19.4969451816
         },
         {
           "eventDate": "2013-09-01T00:00",
           "eventType": "IP",
-          "payoff": "19.4969451816",
+          "payoff": 19.4969451816,
           "currency": "USD",
-          "notionalPrincipal": "1625.0381014776",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 1625.0381014776,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-10-01T00:00",
           "eventType": "PR",
-          "payoff": "435.083617792",
+          "payoff": 435.083617792,
           "currency": "USD",
-          "notionalPrincipal": "1189.9544836856",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "14.9163822079"
+          "notionalPrincipal": 1189.9544836856,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": 14.9163822079
         },
         {
           "eventDate": "2013-10-01T00:00",
           "eventType": "IP",
-          "payoff": "14.9163822079",
+          "payoff": 14.9163822079,
           "currency": "USD",
-          "notionalPrincipal": "1189.9544836856",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 1189.9544836856,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-10-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "1189.9544836856",
-          "nominalInterestRate": "0.1127901234",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 1189.9544836856,
+          "nominalInterestRate": 0.1127901234,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-11-15T00:00",
           "eventType": "IP",
-          "payoff": "16.5470687411",
+          "payoff": 16.5470687411,
           "currency": "USD",
-          "notionalPrincipal": "1189.9544836856",
-          "nominalInterestRate": "0.1127901234",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 1189.9544836856,
+          "nominalInterestRate": 0.1127901234,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-11-15T00:00",
           "eventType": "MD",
-          "payoff": "1189.9544836856",
+          "payoff": 1189.9544836856,
           "currency": "USD",
-          "notionalPrincipal": "0.0",
-          "nominalInterestRate": "0.1127901234",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 0.0,
+          "nominalInterestRate": 0.1127901234,
+          "accruedInterest": 0.0
         }
       ]
     },
@@ -5083,146 +5083,146 @@
         {
           "eventDate": "2013-01-01T00:00",
           "eventType": "IED",
-          "payoff": "-5000.0",
+          "payoff": -5000.0,
           "currency": "USD",
-          "notionalPrincipal": "5000.0",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 5000.0,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-02-01T00:00",
           "eventType": "PR",
-          "payoff": "466.0273972602",
+          "payoff": 466.0273972602,
           "currency": "USD",
-          "notionalPrincipal": "4533.9726027397",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "33.9726027397"
+          "notionalPrincipal": 4533.9726027397,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 33.9726027397
         },
         {
           "eventDate": "2013-02-01T00:00",
           "eventType": "IP",
-          "payoff": "33.9726027397",
+          "payoff": 33.9726027397,
           "currency": "USD",
-          "notionalPrincipal": "4533.9726027397",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4533.9726027397,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-03-01T00:00",
           "eventType": "PR",
-          "payoff": "472.1750722462",
+          "payoff": 472.1750722462,
           "currency": "USD",
-          "notionalPrincipal": "4061.7975304935",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "27.8249277537"
+          "notionalPrincipal": 4061.7975304935,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 27.8249277537
         },
         {
           "eventDate": "2013-03-01T00:00",
           "eventType": "IP",
-          "payoff": "27.8249277537",
+          "payoff": 27.8249277537,
           "currency": "USD",
-          "notionalPrincipal": "4061.7975304935",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4061.7975304935,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-04-01T00:00",
           "eventType": "PR",
-          "payoff": "472.4020332174",
+          "payoff": 472.4020332174,
           "currency": "USD",
-          "notionalPrincipal": "3589.395497276",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "27.5979667825"
+          "notionalPrincipal": 3589.395497276,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 27.5979667825
         },
         {
           "eventDate": "2013-04-01T00:00",
           "eventType": "IP",
-          "payoff": "27.5979667825",
+          "payoff": 27.5979667825,
           "currency": "USD",
-          "notionalPrincipal": "3589.395497276",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 3589.395497276,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-04-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "3589.395497276",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 3589.395497276,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-05-01T00:00",
           "eventType": "PR",
-          "payoff": "467.3803895752",
+          "payoff": 467.3803895752,
           "currency": "USD",
-          "notionalPrincipal": "3122.0151077008",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "32.6196104247"
+          "notionalPrincipal": 3122.0151077008,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 32.6196104247
         },
         {
           "eventDate": "2013-05-01T00:00",
           "eventType": "IP",
-          "payoff": "32.6196104247",
+          "payoff": 32.6196104247,
           "currency": "USD",
-          "notionalPrincipal": "3122.0151077008",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 3122.0151077008,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-06-01T00:00",
           "eventType": "PR",
-          "payoff": "470.6820975328",
+          "payoff": 470.6820975328,
           "currency": "USD",
-          "notionalPrincipal": "2651.3330101679",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "29.3179024671"
+          "notionalPrincipal": 2651.3330101679,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 29.3179024671
         },
         {
           "eventDate": "2013-06-01T00:00",
           "eventType": "IP",
-          "payoff": "29.3179024671",
+          "payoff": 29.3179024671,
           "currency": "USD",
-          "notionalPrincipal": "2651.3330101679",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 2651.3330101679,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-07-01T00:00",
           "eventType": "PR",
-          "payoff": "475.9052882404",
+          "payoff": 475.9052882404,
           "currency": "USD",
-          "notionalPrincipal": "2175.4277219275",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "24.0947117595"
+          "notionalPrincipal": 2175.4277219275,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 24.0947117595
         },
         {
           "eventDate": "2013-07-01T00:00",
           "eventType": "IP",
-          "payoff": "24.0947117595",
+          "payoff": 24.0947117595,
           "currency": "USD",
-          "notionalPrincipal": "2175.4277219275",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 2175.4277219275,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-07-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "2175.4277219275",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 2175.4277219275,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-07-01T00:00",
           "eventType": "TD",
-          "payoff": "2600.0",
+          "payoff": 2600.0,
           "currency": "USD",
-          "notionalPrincipal": "0.0",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 0.0,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": 0.0
         }
       ]
     },
@@ -5293,722 +5293,722 @@
         {
           "eventDate": "2013-01-01T00:00",
           "eventType": "IED",
-          "payoff": "-5000.0",
+          "payoff": -5000.0,
           "currency": "USD",
-          "notionalPrincipal": "5000.0",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 5000.0,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-02-01T00:00",
           "eventType": "PR",
-          "payoff": "6.0273972602",
+          "payoff": 6.0273972602,
           "currency": "USD",
-          "notionalPrincipal": "4993.9726027397",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "33.9726027397"
+          "notionalPrincipal": 4993.9726027397,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 33.9726027397
         },
         {
           "eventDate": "2013-02-01T00:00",
           "eventType": "IP",
-          "payoff": "33.9726027397",
+          "payoff": 33.9726027397,
           "currency": "USD",
-          "notionalPrincipal": "4993.9726027397",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4993.9726027397,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-03-01T00:00",
           "eventType": "PR",
-          "payoff": "9.3520585475",
+          "payoff": 9.3520585475,
           "currency": "USD",
-          "notionalPrincipal": "4984.6205441921",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "30.6479414524"
+          "notionalPrincipal": 4984.6205441921,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 30.6479414524
         },
         {
           "eventDate": "2013-03-01T00:00",
           "eventType": "IP",
-          "payoff": "30.6479414524",
+          "payoff": 30.6479414524,
           "currency": "USD",
-          "notionalPrincipal": "4984.6205441921",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4984.6205441921,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-04-01T00:00",
           "eventType": "PR",
-          "payoff": "6.1318932887",
+          "payoff": 6.1318932887,
           "currency": "USD",
-          "notionalPrincipal": "4978.4886509033",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "33.8681067112"
+          "notionalPrincipal": 4978.4886509033,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 33.8681067112
         },
         {
           "eventDate": "2013-04-01T00:00",
           "eventType": "IP",
-          "payoff": "33.8681067112",
+          "payoff": 33.8681067112,
           "currency": "USD",
-          "notionalPrincipal": "4978.4886509033",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4978.4886509033,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-05-01T00:00",
           "eventType": "PR",
-          "payoff": "7.2647321584",
+          "payoff": 7.2647321584,
           "currency": "USD",
-          "notionalPrincipal": "4971.2239187449",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "32.7352678415"
+          "notionalPrincipal": 4971.2239187449,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 32.7352678415
         },
         {
           "eventDate": "2013-05-01T00:00",
           "eventType": "IP",
-          "payoff": "32.7352678415",
+          "payoff": 32.7352678415,
           "currency": "USD",
-          "notionalPrincipal": "4971.2239187449",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4971.2239187449,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-06-01T00:00",
           "eventType": "PR",
-          "payoff": "6.2229169356",
+          "payoff": 6.2229169356,
           "currency": "USD",
-          "notionalPrincipal": "4965.0010018092",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "33.7770830643"
+          "notionalPrincipal": 4965.0010018092,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 33.7770830643
         },
         {
           "eventDate": "2013-06-01T00:00",
           "eventType": "IP",
-          "payoff": "33.7770830643",
+          "payoff": 33.7770830643,
           "currency": "USD",
-          "notionalPrincipal": "4965.0010018092",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4965.0010018092,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-07-01T00:00",
           "eventType": "PR",
-          "payoff": "7.3534180702",
+          "payoff": 7.3534180702,
           "currency": "USD",
-          "notionalPrincipal": "4957.6475837389",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "32.6465819297"
+          "notionalPrincipal": 4957.6475837389,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 32.6465819297
         },
         {
           "eventDate": "2013-07-01T00:00",
           "eventType": "IP",
-          "payoff": "32.6465819297",
+          "payoff": 32.6465819297,
           "currency": "USD",
-          "notionalPrincipal": "4957.6475837389",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4957.6475837389,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-08-01T00:00",
           "eventType": "PR",
-          "payoff": "6.3151616228",
+          "payoff": 6.3151616228,
           "currency": "USD",
-          "notionalPrincipal": "4951.3324221161",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "33.6848383771"
+          "notionalPrincipal": 4951.3324221161,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 33.6848383771
         },
         {
           "eventDate": "2013-08-01T00:00",
           "eventType": "IP",
-          "payoff": "33.6848383771",
+          "payoff": 33.6848383771,
           "currency": "USD",
-          "notionalPrincipal": "4951.3324221161",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4951.3324221161,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-09-01T00:00",
           "eventType": "PR",
-          "payoff": "6.3580701182",
+          "payoff": 6.3580701182,
           "currency": "USD",
-          "notionalPrincipal": "4944.9743519979",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "33.6419298817"
+          "notionalPrincipal": 4944.9743519979,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 33.6419298817
         },
         {
           "eventDate": "2013-09-01T00:00",
           "eventType": "IP",
-          "payoff": "33.6419298817",
+          "payoff": 33.6419298817,
           "currency": "USD",
-          "notionalPrincipal": "4944.9743519979",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4944.9743519979,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-10-01T00:00",
           "eventType": "PR",
-          "payoff": "7.4851001512",
+          "payoff": 7.4851001512,
           "currency": "USD",
-          "notionalPrincipal": "4937.4892518467",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "32.5148998487"
+          "notionalPrincipal": 4937.4892518467,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 32.5148998487
         },
         {
           "eventDate": "2013-10-01T00:00",
           "eventType": "IP",
-          "payoff": "32.5148998487",
+          "payoff": 32.5148998487,
           "currency": "USD",
-          "notionalPrincipal": "4937.4892518467",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4937.4892518467,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-11-01T00:00",
           "eventType": "PR",
-          "payoff": "6.452127823",
+          "payoff": 6.452127823,
           "currency": "USD",
-          "notionalPrincipal": "4931.0371240236",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "33.5478721769"
+          "notionalPrincipal": 4931.0371240236,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 33.5478721769
         },
         {
           "eventDate": "2013-11-01T00:00",
           "eventType": "IP",
-          "payoff": "33.5478721769",
+          "payoff": 33.5478721769,
           "currency": "USD",
-          "notionalPrincipal": "4931.0371240236",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4931.0371240236,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-12-01T00:00",
           "eventType": "PR",
-          "payoff": "7.5767421982",
+          "payoff": 7.5767421982,
           "currency": "USD",
-          "notionalPrincipal": "4923.4603818254",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "32.4232578017"
+          "notionalPrincipal": 4923.4603818254,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 32.4232578017
         },
         {
           "eventDate": "2013-12-01T00:00",
           "eventType": "IP",
-          "payoff": "32.4232578017",
+          "payoff": 32.4232578017,
           "currency": "USD",
-          "notionalPrincipal": "4923.4603818254",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4923.4603818254,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-01-01T00:00",
           "eventType": "PR",
-          "payoff": "6.5474472686",
+          "payoff": 6.5474472686,
           "currency": "USD",
-          "notionalPrincipal": "4916.9129345567",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "33.4525527313"
+          "notionalPrincipal": 4916.9129345567,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 33.4525527313
         },
         {
           "eventDate": "2014-01-01T00:00",
           "eventType": "IP",
-          "payoff": "33.4525527313",
+          "payoff": 33.4525527313,
           "currency": "USD",
-          "notionalPrincipal": "4916.9129345567",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4916.9129345567,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-02-01T00:00",
           "eventType": "PR",
-          "payoff": "6.5919340336",
+          "payoff": 6.5919340336,
           "currency": "USD",
-          "notionalPrincipal": "4910.321000523",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "33.4080659663"
+          "notionalPrincipal": 4910.321000523,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 33.4080659663
         },
         {
           "eventDate": "2014-02-01T00:00",
           "eventType": "IP",
-          "payoff": "33.4080659663",
+          "payoff": 33.4080659663,
           "currency": "USD",
-          "notionalPrincipal": "4910.321000523",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4910.321000523,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-03-01T00:00",
           "eventType": "PR",
-          "payoff": "9.8654272844",
+          "payoff": 9.8654272844,
           "currency": "USD",
-          "notionalPrincipal": "4900.4555732385",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "30.1345727155"
+          "notionalPrincipal": 4900.4555732385,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 30.1345727155
         },
         {
           "eventDate": "2014-03-01T00:00",
           "eventType": "IP",
-          "payoff": "30.1345727155",
+          "payoff": 30.1345727155,
           "currency": "USD",
-          "notionalPrincipal": "4900.4555732385",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4900.4555732385,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-04-01T00:00",
           "eventType": "PR",
-          "payoff": "6.7037539133",
+          "payoff": 6.7037539133,
           "currency": "USD",
-          "notionalPrincipal": "4893.7518193252",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "33.2962460866"
+          "notionalPrincipal": 4893.7518193252,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 33.2962460866
         },
         {
           "eventDate": "2014-04-01T00:00",
           "eventType": "IP",
-          "payoff": "33.2962460866",
+          "payoff": 33.2962460866,
           "currency": "USD",
-          "notionalPrincipal": "4893.7518193252",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4893.7518193252,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-04-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "4893.7518193252",
-          "nominalInterestRate": "0.1350123456",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4893.7518193252,
+          "nominalInterestRate": 0.1350123456,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-05-01T00:00",
           "eventType": "PR",
-          "payoff": "-14.305499641",
+          "payoff": -14.305499641,
           "currency": "USD",
-          "notionalPrincipal": "4908.0573189661",
-          "nominalInterestRate": "0.1350123456",
-          "accruedInterest": "54.3054996409"
+          "notionalPrincipal": 4908.0573189661,
+          "nominalInterestRate": 0.1350123456,
+          "accruedInterest": 54.3054996409
         },
         {
           "eventDate": "2014-05-01T00:00",
           "eventType": "IP",
-          "payoff": "54.3054996409",
+          "payoff": 54.3054996409,
           "currency": "USD",
-          "notionalPrincipal": "4908.0573189661",
-          "nominalInterestRate": "0.1350123456",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4908.0573189661,
+          "nominalInterestRate": 0.1350123456,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-06-01T00:00",
           "eventType": "PR",
-          "payoff": "-16.2797212937",
+          "payoff": -16.2797212937,
           "currency": "USD",
-          "notionalPrincipal": "4924.3370402598",
-          "nominalInterestRate": "0.1350123456",
-          "accruedInterest": "56.2797212936"
+          "notionalPrincipal": 4924.3370402598,
+          "nominalInterestRate": 0.1350123456,
+          "accruedInterest": 56.2797212936
         },
         {
           "eventDate": "2014-06-01T00:00",
           "eventType": "IP",
-          "payoff": "56.2797212936",
+          "payoff": 56.2797212936,
           "currency": "USD",
-          "notionalPrincipal": "4924.3370402598",
-          "nominalInterestRate": "0.1350123456",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4924.3370402598,
+          "nominalInterestRate": 0.1350123456,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-07-01T00:00",
           "eventType": "PR",
-          "payoff": "-14.6449009359",
+          "payoff": -14.6449009359,
           "currency": "USD",
-          "notionalPrincipal": "4938.9819411956",
-          "nominalInterestRate": "0.1350123456",
-          "accruedInterest": "54.6449009358"
+          "notionalPrincipal": 4938.9819411956,
+          "nominalInterestRate": 0.1350123456,
+          "accruedInterest": 54.6449009358
         },
         {
           "eventDate": "2014-07-01T00:00",
           "eventType": "IP",
-          "payoff": "54.6449009358",
+          "payoff": 54.6449009358,
           "currency": "USD",
-          "notionalPrincipal": "4938.9819411956",
-          "nominalInterestRate": "0.1350123456",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4938.9819411956,
+          "nominalInterestRate": 0.1350123456,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-07-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "4938.9819411956",
-          "nominalInterestRate": "0.1361234567",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4938.9819411956,
+          "nominalInterestRate": 0.1361234567,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-08-01T00:00",
           "eventType": "PR",
-          "payoff": "-17.1004113443",
+          "payoff": -17.1004113443,
           "currency": "USD",
-          "notionalPrincipal": "4956.0823525399",
-          "nominalInterestRate": "0.1361234567",
-          "accruedInterest": "57.1004113442"
+          "notionalPrincipal": 4956.0823525399,
+          "nominalInterestRate": 0.1361234567,
+          "accruedInterest": 57.1004113442
         },
         {
           "eventDate": "2014-08-01T00:00",
           "eventType": "IP",
-          "payoff": "57.1004113442",
+          "payoff": 57.1004113442,
           "currency": "USD",
-          "notionalPrincipal": "4956.0823525399",
-          "nominalInterestRate": "0.1361234567",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4956.0823525399,
+          "nominalInterestRate": 0.1361234567,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-09-01T00:00",
           "eventType": "PR",
-          "payoff": "-17.2981121121",
+          "payoff": -17.2981121121,
           "currency": "USD",
-          "notionalPrincipal": "4973.3804646519",
-          "nominalInterestRate": "0.1361234567",
-          "accruedInterest": "57.298112112"
+          "notionalPrincipal": 4973.3804646519,
+          "nominalInterestRate": 0.1361234567,
+          "accruedInterest": 57.298112112
         },
         {
           "eventDate": "2014-09-01T00:00",
           "eventType": "IP",
-          "payoff": "57.298112112",
+          "payoff": 57.298112112,
           "currency": "USD",
-          "notionalPrincipal": "4973.3804646519",
-          "nominalInterestRate": "0.1361234567",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4973.3804646519,
+          "nominalInterestRate": 0.1361234567,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-10-01T00:00",
           "eventType": "PR",
-          "payoff": "-15.6433211601",
+          "payoff": -15.6433211601,
           "currency": "USD",
-          "notionalPrincipal": "4989.023785812",
-          "nominalInterestRate": "0.1361234567",
-          "accruedInterest": "55.64332116"
+          "notionalPrincipal": 4989.023785812,
+          "nominalInterestRate": 0.1361234567,
+          "accruedInterest": 55.64332116
         },
         {
           "eventDate": "2014-10-01T00:00",
           "eventType": "IP",
-          "payoff": "55.64332116",
+          "payoff": 55.64332116,
           "currency": "USD",
-          "notionalPrincipal": "4989.023785812",
-          "nominalInterestRate": "0.1361234567",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4989.023785812,
+          "nominalInterestRate": 0.1361234567,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-10-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "4989.023785812",
-          "nominalInterestRate": "0.1372345679",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4989.023785812,
+          "nominalInterestRate": 0.1372345679,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-11-01T00:00",
           "eventType": "PR",
-          "payoff": "-18.1497595298",
+          "payoff": -18.1497595298,
           "currency": "USD",
-          "notionalPrincipal": "5007.1735453417",
-          "nominalInterestRate": "0.1372345679",
-          "accruedInterest": "58.1497595297"
+          "notionalPrincipal": 5007.1735453417,
+          "nominalInterestRate": 0.1372345679,
+          "accruedInterest": 58.1497595297
         },
         {
           "eventDate": "2014-11-01T00:00",
           "eventType": "IP",
-          "payoff": "58.1497595297",
+          "payoff": 58.1497595297,
           "currency": "USD",
-          "notionalPrincipal": "5007.1735453417",
-          "nominalInterestRate": "0.1372345679",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 5007.1735453417,
+          "nominalInterestRate": 0.1372345679,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-12-01T00:00",
           "eventType": "PR",
-          "payoff": "-16.4786820193",
+          "payoff": -16.4786820193,
           "currency": "USD",
-          "notionalPrincipal": "5023.652227361",
-          "nominalInterestRate": "0.1372345679",
-          "accruedInterest": "56.4786820192"
+          "notionalPrincipal": 5023.652227361,
+          "nominalInterestRate": 0.1372345679,
+          "accruedInterest": 56.4786820192
         },
         {
           "eventDate": "2014-12-01T00:00",
           "eventType": "IP",
-          "payoff": "56.4786820192",
+          "payoff": 56.4786820192,
           "currency": "USD",
-          "notionalPrincipal": "5023.652227361",
-          "nominalInterestRate": "0.1372345679",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 5023.652227361,
+          "nominalInterestRate": 0.1372345679,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2015-01-01T00:00",
           "eventType": "PR",
-          "payoff": "-18.5533726684",
+          "payoff": -18.5533726684,
           "currency": "USD",
-          "notionalPrincipal": "5042.2056000293",
-          "nominalInterestRate": "0.1372345679",
-          "accruedInterest": "58.5533726683"
+          "notionalPrincipal": 5042.2056000293,
+          "nominalInterestRate": 0.1372345679,
+          "accruedInterest": 58.5533726683
         },
         {
           "eventDate": "2015-01-01T00:00",
           "eventType": "IP",
-          "payoff": "58.5533726683",
+          "payoff": 58.5533726683,
           "currency": "USD",
-          "notionalPrincipal": "5042.2056000293",
-          "nominalInterestRate": "0.1372345679",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 5042.2056000293,
+          "nominalInterestRate": 0.1372345679,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2015-01-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "5042.2056000293",
-          "nominalInterestRate": "0.138345679",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 5042.2056000293,
+          "nominalInterestRate": 0.138345679,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2015-02-01T00:00",
           "eventType": "PR",
-          "payoff": "-19.2454467977",
+          "payoff": -19.2454467977,
           "currency": "USD",
-          "notionalPrincipal": "5061.4510468269",
-          "nominalInterestRate": "0.138345679",
-          "accruedInterest": "59.2454467976"
+          "notionalPrincipal": 5061.4510468269,
+          "nominalInterestRate": 0.138345679,
+          "accruedInterest": 59.2454467976
         },
         {
           "eventDate": "2015-02-01T00:00",
           "eventType": "IP",
-          "payoff": "59.2454467976",
+          "payoff": 59.2454467976,
           "currency": "USD",
-          "notionalPrincipal": "5061.4510468269",
-          "nominalInterestRate": "0.138345679",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 5061.4510468269,
+          "nominalInterestRate": 0.138345679,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2015-03-01T00:00",
           "eventType": "PR",
-          "payoff": "-13.7162649099",
+          "payoff": -13.7162649099,
           "currency": "USD",
-          "notionalPrincipal": "5075.1673117368",
-          "nominalInterestRate": "0.138345679",
-          "accruedInterest": "53.7162649098"
+          "notionalPrincipal": 5075.1673117368,
+          "nominalInterestRate": 0.138345679,
+          "accruedInterest": 53.7162649098
         },
         {
           "eventDate": "2015-03-01T00:00",
           "eventType": "IP",
-          "payoff": "53.7162649098",
+          "payoff": 53.7162649098,
           "currency": "USD",
-          "notionalPrincipal": "5075.1673117368",
-          "nominalInterestRate": "0.138345679",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 5075.1673117368,
+          "nominalInterestRate": 0.138345679,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2015-04-01T00:00",
           "eventType": "PR",
-          "payoff": "-19.6327438443",
+          "payoff": -19.6327438443,
           "currency": "USD",
-          "notionalPrincipal": "5094.8000555811",
-          "nominalInterestRate": "0.138345679",
-          "accruedInterest": "59.6327438442"
+          "notionalPrincipal": 5094.8000555811,
+          "nominalInterestRate": 0.138345679,
+          "accruedInterest": 59.6327438442
         },
         {
           "eventDate": "2015-04-01T00:00",
           "eventType": "IP",
-          "payoff": "59.6327438442",
+          "payoff": 59.6327438442,
           "currency": "USD",
-          "notionalPrincipal": "5094.8000555811",
-          "nominalInterestRate": "0.138345679",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 5094.8000555811,
+          "nominalInterestRate": 0.138345679,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2015-04-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "5094.8000555811",
-          "nominalInterestRate": "0.1394567901",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 5094.8000555811,
+          "nominalInterestRate": 0.1394567901,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2015-05-01T00:00",
           "eventType": "PR",
-          "payoff": "-18.3976270197",
+          "payoff": -18.3976270197,
           "currency": "USD",
-          "notionalPrincipal": "5113.1976826007",
-          "nominalInterestRate": "0.1394567901",
-          "accruedInterest": "58.3976270196"
+          "notionalPrincipal": 5113.1976826007,
+          "nominalInterestRate": 0.1394567901,
+          "accruedInterest": 58.3976270196
         },
         {
           "eventDate": "2015-05-01T00:00",
           "eventType": "IP",
-          "payoff": "58.3976270196",
+          "payoff": 58.3976270196,
           "currency": "USD",
-          "notionalPrincipal": "5113.1976826007",
-          "nominalInterestRate": "0.1394567901",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 5113.1976826007,
+          "nominalInterestRate": 0.1394567901,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2015-06-01T00:00",
           "eventType": "PR",
-          "payoff": "-20.5621211468",
+          "payoff": -20.5621211468,
           "currency": "USD",
-          "notionalPrincipal": "5133.7598037474",
-          "nominalInterestRate": "0.1394567901",
-          "accruedInterest": "60.5621211467"
+          "notionalPrincipal": 5133.7598037474,
+          "nominalInterestRate": 0.1394567901,
+          "accruedInterest": 60.5621211467
         },
         {
           "eventDate": "2015-06-01T00:00",
           "eventType": "IP",
-          "payoff": "60.5621211467",
+          "payoff": 60.5621211467,
           "currency": "USD",
-          "notionalPrincipal": "5133.7598037474",
-          "nominalInterestRate": "0.1394567901",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 5133.7598037474,
+          "nominalInterestRate": 0.1394567901,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2015-07-01T00:00",
           "eventType": "PR",
-          "payoff": "-18.8441915202",
+          "payoff": -18.8441915202,
           "currency": "USD",
-          "notionalPrincipal": "5152.6039952676",
-          "nominalInterestRate": "0.1394567901",
-          "accruedInterest": "58.8441915201"
+          "notionalPrincipal": 5152.6039952676,
+          "nominalInterestRate": 0.1394567901,
+          "accruedInterest": 58.8441915201
         },
         {
           "eventDate": "2015-07-01T00:00",
           "eventType": "IP",
-          "payoff": "58.8441915201",
+          "payoff": 58.8441915201,
           "currency": "USD",
-          "notionalPrincipal": "5152.6039952676",
-          "nominalInterestRate": "0.1394567901",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 5152.6039952676,
+          "nominalInterestRate": 0.1394567901,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2015-07-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "5152.6039952676",
-          "nominalInterestRate": "0.1405679012",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 5152.6039952676,
+          "nominalInterestRate": 0.1405679012,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2015-08-01T00:00",
           "eventType": "PR",
-          "payoff": "-21.5151030541",
+          "payoff": -21.5151030541,
           "currency": "USD",
-          "notionalPrincipal": "5174.1190983217",
-          "nominalInterestRate": "0.1405679012",
-          "accruedInterest": "61.515103054"
+          "notionalPrincipal": 5174.1190983217,
+          "nominalInterestRate": 0.1405679012,
+          "accruedInterest": 61.515103054
         },
         {
           "eventDate": "2015-08-01T00:00",
           "eventType": "IP",
-          "payoff": "61.515103054",
+          "payoff": 61.515103054,
           "currency": "USD",
-          "notionalPrincipal": "5174.1190983217",
-          "nominalInterestRate": "0.1405679012",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 5174.1190983217,
+          "nominalInterestRate": 0.1405679012,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2015-09-01T00:00",
           "eventType": "PR",
-          "payoff": "-21.7719642029",
+          "payoff": -21.7719642029,
           "currency": "USD",
-          "notionalPrincipal": "5195.8910625245",
-          "nominalInterestRate": "0.1405679012",
-          "accruedInterest": "61.7719642028"
+          "notionalPrincipal": 5195.8910625245,
+          "nominalInterestRate": 0.1405679012,
+          "accruedInterest": 61.7719642028
         },
         {
           "eventDate": "2015-09-01T00:00",
           "eventType": "IP",
-          "payoff": "61.7719642028",
+          "payoff": 61.7719642028,
           "currency": "USD",
-          "notionalPrincipal": "5195.8910625245",
-          "nominalInterestRate": "0.1405679012",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 5195.8910625245,
+          "nominalInterestRate": 0.1405679012,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2015-10-01T00:00",
           "eventType": "PR",
-          "payoff": "-20.0308631537",
+          "payoff": -20.0308631537,
           "currency": "USD",
-          "notionalPrincipal": "5215.9219256782",
-          "nominalInterestRate": "0.1405679012",
-          "accruedInterest": "60.0308631536"
+          "notionalPrincipal": 5215.9219256782,
+          "nominalInterestRate": 0.1405679012,
+          "accruedInterest": 60.0308631536
         },
         {
           "eventDate": "2015-10-01T00:00",
           "eventType": "IP",
-          "payoff": "60.0308631536",
+          "payoff": 60.0308631536,
           "currency": "USD",
-          "notionalPrincipal": "5215.9219256782",
-          "nominalInterestRate": "0.1405679012",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 5215.9219256782,
+          "nominalInterestRate": 0.1405679012,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2015-10-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "5215.9219256782",
-          "nominalInterestRate": "0.1416790123",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 5215.9219256782,
+          "nominalInterestRate": 0.1416790123,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2015-11-01T00:00",
           "eventType": "PR",
-          "payoff": "-22.7632511616",
+          "payoff": -22.7632511616,
           "currency": "USD",
-          "notionalPrincipal": "5238.6851768397",
-          "nominalInterestRate": "0.1416790123",
-          "accruedInterest": "62.7632511615"
+          "notionalPrincipal": 5238.6851768397,
+          "nominalInterestRate": 0.1416790123,
+          "accruedInterest": 62.7632511615
         },
         {
           "eventDate": "2015-11-01T00:00",
           "eventType": "IP",
-          "payoff": "62.7632511615",
+          "payoff": 62.7632511615,
           "currency": "USD",
-          "notionalPrincipal": "5238.6851768397",
-          "nominalInterestRate": "0.1416790123",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 5238.6851768397,
+          "nominalInterestRate": 0.1416790123,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2015-12-01T00:00",
           "eventType": "PR",
-          "payoff": "-21.0037048092",
+          "payoff": -21.0037048092,
           "currency": "USD",
-          "notionalPrincipal": "5259.6888816489",
-          "nominalInterestRate": "0.1416790123",
-          "accruedInterest": "61.0037048091"
+          "notionalPrincipal": 5259.6888816489,
+          "nominalInterestRate": 0.1416790123,
+          "accruedInterest": 61.0037048091
         },
         {
           "eventDate": "2015-12-01T00:00",
           "eventType": "IP",
-          "payoff": "61.0037048091",
+          "payoff": 61.0037048091,
           "currency": "USD",
-          "notionalPrincipal": "5259.6888816489",
-          "nominalInterestRate": "0.1416790123",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 5259.6888816489,
+          "nominalInterestRate": 0.1416790123,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2016-01-01T00:00",
           "eventType": "IP",
-          "payoff": "63.2898994682",
+          "payoff": 63.2898994682,
           "currency": "USD",
-          "notionalPrincipal": "5259.6888816489",
-          "nominalInterestRate": "0.1416790123",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 5259.6888816489,
+          "nominalInterestRate": 0.1416790123,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2016-01-01T00:00",
           "eventType": "MD",
-          "payoff": "5259.6888816489",
+          "payoff": 5259.6888816489,
           "currency": "USD",
-          "notionalPrincipal": "0.0",
-          "nominalInterestRate": "0.1416790123",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 0.0,
+          "nominalInterestRate": 0.1416790123,
+          "accruedInterest": 0.0
         }
       ]
     },
@@ -6095,236 +6095,236 @@
         {
           "eventDate": "2013-01-01T00:00",
           "eventType": "IED",
-          "payoff": "5000.0",
+          "payoff": 5000.0,
           "currency": "USD",
-          "notionalPrincipal": "-5000.0",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": -5000.0,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-02-01T00:00",
           "eventType": "PR",
-          "payoff": "-466.0273972603",
+          "payoff": -466.0273972603,
           "currency": "USD",
-          "notionalPrincipal": "-4533.9726027398",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "-33.9726027398"
+          "notionalPrincipal": -4533.9726027398,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": -33.9726027398
         },
         {
           "eventDate": "2013-02-01T00:00",
           "eventType": "IP",
-          "payoff": "-33.9726027398",
+          "payoff": -33.9726027398,
           "currency": "USD",
-          "notionalPrincipal": "-4533.9726027398",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": -4533.9726027398,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-03-01T00:00",
           "eventType": "PR",
-          "payoff": "-472.1750722463",
+          "payoff": -472.1750722463,
           "currency": "USD",
-          "notionalPrincipal": "-4061.7975304936",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "-27.8249277538"
+          "notionalPrincipal": -4061.7975304936,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": -27.8249277538
         },
         {
           "eventDate": "2013-03-01T00:00",
           "eventType": "IP",
-          "payoff": "-27.8249277538",
+          "payoff": -27.8249277538,
           "currency": "USD",
-          "notionalPrincipal": "-4061.7975304936",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": -4061.7975304936,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-04-01T00:00",
           "eventType": "PR",
-          "payoff": "-472.4020332175",
+          "payoff": -472.4020332175,
           "currency": "USD",
-          "notionalPrincipal": "-3589.3954972761",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "-27.5979667826"
+          "notionalPrincipal": -3589.3954972761,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": -27.5979667826
         },
         {
           "eventDate": "2013-04-01T00:00",
           "eventType": "IP",
-          "payoff": "-27.5979667826",
+          "payoff": -27.5979667826,
           "currency": "USD",
-          "notionalPrincipal": "-3589.3954972761",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": -3589.3954972761,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-04-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "-3589.3954972761",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": -3589.3954972761,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-05-01T00:00",
           "eventType": "PR",
-          "payoff": "-467.3803895753",
+          "payoff": -467.3803895753,
           "currency": "USD",
-          "notionalPrincipal": "-3122.0151077009",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "-32.6196104248"
+          "notionalPrincipal": -3122.0151077009,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": -32.6196104248
         },
         {
           "eventDate": "2013-05-01T00:00",
           "eventType": "IP",
-          "payoff": "-32.6196104248",
+          "payoff": -32.6196104248,
           "currency": "USD",
-          "notionalPrincipal": "-3122.0151077009",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": -3122.0151077009,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-06-01T00:00",
           "eventType": "PR",
-          "payoff": "-470.6820975329",
+          "payoff": -470.6820975329,
           "currency": "USD",
-          "notionalPrincipal": "-2651.333010168",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "-29.3179024672"
+          "notionalPrincipal": -2651.333010168,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": -29.3179024672
         },
         {
           "eventDate": "2013-06-01T00:00",
           "eventType": "IP",
-          "payoff": "-29.3179024672",
+          "payoff": -29.3179024672,
           "currency": "USD",
-          "notionalPrincipal": "-2651.333010168",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": -2651.333010168,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-07-01T00:00",
           "eventType": "PR",
-          "payoff": "-475.9052882405",
+          "payoff": -475.9052882405,
           "currency": "USD",
-          "notionalPrincipal": "-2175.4277219276",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "-24.0947117596"
+          "notionalPrincipal": -2175.4277219276,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": -24.0947117596
         },
         {
           "eventDate": "2013-07-01T00:00",
           "eventType": "IP",
-          "payoff": "-24.0947117596",
+          "payoff": -24.0947117596,
           "currency": "USD",
-          "notionalPrincipal": "-2175.4277219276",
-          "nominalInterestRate": "0.1105679012",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": -2175.4277219276,
+          "nominalInterestRate": 0.1105679012,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-07-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "-2175.4277219276",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": -2175.4277219276,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-08-01T00:00",
           "eventType": "PR",
-          "payoff": "-479.3659227347",
+          "payoff": -479.3659227347,
           "currency": "USD",
-          "notionalPrincipal": "-1696.0617991929",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "-20.6340772654"
+          "notionalPrincipal": -1696.0617991929,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": -20.6340772654
         },
         {
           "eventDate": "2013-08-01T00:00",
           "eventType": "IP",
-          "payoff": "-20.6340772654",
+          "payoff": -20.6340772654,
           "currency": "USD",
-          "notionalPrincipal": "-1696.0617991929",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": -1696.0617991929,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-09-01T00:00",
           "eventType": "PR",
-          "payoff": "-483.9127405345",
+          "payoff": -483.9127405345,
           "currency": "USD",
-          "notionalPrincipal": "-1212.1490586585",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "-16.0872594656"
+          "notionalPrincipal": -1212.1490586585,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": -16.0872594656
         },
         {
           "eventDate": "2013-09-01T00:00",
           "eventType": "IP",
-          "payoff": "-16.0872594656",
+          "payoff": -16.0872594656,
           "currency": "USD",
-          "notionalPrincipal": "-1212.1490586585",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": -1212.1490586585,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-10-01T00:00",
           "eventType": "PR",
-          "payoff": "-488.8735663272",
+          "payoff": -488.8735663272,
           "currency": "USD",
-          "notionalPrincipal": "-723.2754923314",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "-11.1264336729"
+          "notionalPrincipal": -723.2754923314,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": -11.1264336729
         },
         {
           "eventDate": "2013-10-01T00:00",
           "eventType": "IP",
-          "payoff": "-11.1264336729",
+          "payoff": -11.1264336729,
           "currency": "USD",
-          "notionalPrincipal": "-723.2754923314",
-          "nominalInterestRate": "0.1116790123",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": -723.2754923314,
+          "nominalInterestRate": 0.1116790123,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-10-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "-723.2754923314",
-          "nominalInterestRate": "0.1127901234",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": -723.2754923314,
+          "nominalInterestRate": 0.1127901234,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-11-01T00:00",
           "eventType": "PR",
-          "payoff": "-493.0714293308",
+          "payoff": -493.0714293308,
           "currency": "USD",
-          "notionalPrincipal": "-230.2040630007",
-          "nominalInterestRate": "0.1127901234",
-          "accruedInterest": "-6.9285706693"
+          "notionalPrincipal": -230.2040630007,
+          "nominalInterestRate": 0.1127901234,
+          "accruedInterest": -6.9285706693
         },
         {
           "eventDate": "2013-11-01T00:00",
           "eventType": "IP",
-          "payoff": "-6.9285706693",
+          "payoff": -6.9285706693,
           "currency": "USD",
-          "notionalPrincipal": "-230.2040630007",
-          "nominalInterestRate": "0.1127901234",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": -230.2040630007,
+          "nominalInterestRate": 0.1127901234,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-12-01T00:00",
           "eventType": "IP",
-          "payoff": "-2.1340886044",
+          "payoff": -2.1340886044,
           "currency": "USD",
-          "notionalPrincipal": "-230.2040630007",
-          "nominalInterestRate": "0.1127901234",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": -230.2040630007,
+          "nominalInterestRate": 0.1127901234,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-12-01T00:00",
           "eventType": "MD",
-          "payoff": "-230.2040630007",
+          "payoff": -230.2040630007,
           "currency": "USD",
-          "notionalPrincipal": "0.0",
-          "nominalInterestRate": "0.1127901234",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 0.0,
+          "nominalInterestRate": 0.1127901234,
+          "accruedInterest": 0.0
         }
       ]
     },
@@ -6727,227 +6727,227 @@
         {
           "eventDate": "2013-01-01T00:00",
           "eventType": "IED",
-          "payoff": "-5000.0",
+          "payoff": -5000.0,
           "currency": "USD",
-          "notionalPrincipal": "5000.0",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 5000.0,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-02-01T00:00",
           "eventType": "PR",
-          "payoff": "566.0273972602",
+          "payoff": 566.0273972602,
           "currency": "USD",
-          "notionalPrincipal": "4433.9726027397",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "33.9726027397"
+          "notionalPrincipal": 4433.9726027397,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 33.9726027397
         },
         {
           "eventDate": "2013-02-01T00:00",
           "eventType": "IP",
-          "payoff": "33.9726027397",
+          "payoff": 33.9726027397,
           "currency": "USD",
-          "notionalPrincipal": "4433.9726027397",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4433.9726027397,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-05-01T00:00",
           "eventType": "PR",
-          "payoff": "513.5071645712",
+          "payoff": 513.5071645712,
           "currency": "USD",
-          "notionalPrincipal": "3920.4654381685",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "86.4928354287"
+          "notionalPrincipal": 3920.4654381685,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 86.4928354287
         },
         {
           "eventDate": "2013-05-01T00:00",
           "eventType": "IP",
-          "payoff": "86.4928354287",
+          "payoff": 86.4928354287,
           "currency": "USD",
-          "notionalPrincipal": "3920.4654381685",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 3920.4654381685,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-06-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "3920.4654381685",
-          "nominalInterestRate": "0.1118641975",
-          "accruedInterest": "26.6376829771"
+          "notionalPrincipal": 3920.4654381685,
+          "nominalInterestRate": 0.1118641975,
+          "accruedInterest": 26.6376829771
         },
         {
           "eventDate": "2013-08-01T00:00",
           "eventType": "PR",
-          "payoff": "500.0687747452",
+          "payoff": 500.0687747452,
           "currency": "USD",
-          "notionalPrincipal": "3420.3966634232",
-          "nominalInterestRate": "0.1118641975",
-          "accruedInterest": "99.9312252547"
+          "notionalPrincipal": 3420.3966634232,
+          "nominalInterestRate": 0.1118641975,
+          "accruedInterest": 99.9312252547
         },
         {
           "eventDate": "2013-08-01T00:00",
           "eventType": "IP",
-          "payoff": "99.9312252547",
+          "payoff": 99.9312252547,
           "currency": "USD",
-          "notionalPrincipal": "3420.3966634232",
-          "nominalInterestRate": "0.1118641975",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 3420.3966634232,
+          "nominalInterestRate": 0.1118641975,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-11-01T00:00",
           "eventType": "PR",
-          "payoff": "503.5588126712",
+          "payoff": 503.5588126712,
           "currency": "USD",
-          "notionalPrincipal": "2916.837850752",
-          "nominalInterestRate": "0.1118641975",
-          "accruedInterest": "96.4411873287"
+          "notionalPrincipal": 2916.837850752,
+          "nominalInterestRate": 0.1118641975,
+          "accruedInterest": 96.4411873287
         },
         {
           "eventDate": "2013-11-01T00:00",
           "eventType": "IP",
-          "payoff": "96.4411873287",
+          "payoff": 96.4411873287,
           "currency": "USD",
-          "notionalPrincipal": "2916.837850752",
-          "nominalInterestRate": "0.1118641975",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 2916.837850752,
+          "nominalInterestRate": 0.1118641975,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-12-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "2916.837850752",
-          "nominalInterestRate": "0.1140864197",
-          "accruedInterest": "26.8183336027"
+          "notionalPrincipal": 2916.837850752,
+          "nominalInterestRate": 0.1140864197,
+          "accruedInterest": 26.8183336027
         },
         {
           "eventDate": "2014-02-01T00:00",
           "eventType": "PR",
-          "payoff": "516.6560816894",
+          "payoff": 516.6560816894,
           "currency": "USD",
-          "notionalPrincipal": "2400.1817690625",
-          "nominalInterestRate": "0.1140864197",
-          "accruedInterest": "83.3439183105"
+          "notionalPrincipal": 2400.1817690625,
+          "nominalInterestRate": 0.1140864197,
+          "accruedInterest": 83.3439183105
         },
         {
           "eventDate": "2014-02-01T00:00",
           "eventType": "IP",
-          "payoff": "83.3439183105",
+          "payoff": 83.3439183105,
           "currency": "USD",
-          "notionalPrincipal": "2400.1817690625",
-          "nominalInterestRate": "0.1140864197",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 2400.1817690625,
+          "nominalInterestRate": 0.1140864197,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-05-01T00:00",
           "eventType": "PR",
-          "payoff": "533.2309455172",
+          "payoff": 533.2309455172,
           "currency": "USD",
-          "notionalPrincipal": "1866.9508235453",
-          "nominalInterestRate": "0.1140864197",
-          "accruedInterest": "66.7690544827"
+          "notionalPrincipal": 1866.9508235453,
+          "nominalInterestRate": 0.1140864197,
+          "accruedInterest": 66.7690544827
         },
         {
           "eventDate": "2014-05-01T00:00",
           "eventType": "IP",
-          "payoff": "66.7690544827",
+          "payoff": 66.7690544827,
           "currency": "USD",
-          "notionalPrincipal": "1866.9508235453",
-          "nominalInterestRate": "0.1140864197",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 1866.9508235453,
+          "nominalInterestRate": 0.1140864197,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-06-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "1866.9508235453",
-          "nominalInterestRate": "0.1163086419",
-          "accruedInterest": "18.0898788896"
+          "notionalPrincipal": 1866.9508235453,
+          "nominalInterestRate": 0.1163086419,
+          "accruedInterest": 18.0898788896
         },
         {
           "eventDate": "2014-08-01T00:00",
           "eventType": "PR",
-          "payoff": "545.6205501235",
+          "payoff": 545.6205501235,
           "currency": "USD",
-          "notionalPrincipal": "1321.3302734218",
-          "nominalInterestRate": "0.1163086419",
-          "accruedInterest": "54.3794498764"
+          "notionalPrincipal": 1321.3302734218,
+          "nominalInterestRate": 0.1163086419,
+          "accruedInterest": 54.3794498764
         },
         {
           "eventDate": "2014-08-01T00:00",
           "eventType": "IP",
-          "payoff": "54.3794498764",
+          "payoff": 54.3794498764,
           "currency": "USD",
-          "notionalPrincipal": "1321.3302734218",
-          "nominalInterestRate": "0.1163086419",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 1321.3302734218,
+          "nominalInterestRate": 0.1163086419,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-11-01T00:00",
           "eventType": "PR",
-          "payoff": "561.2636823763",
+          "payoff": 561.2636823763,
           "currency": "USD",
-          "notionalPrincipal": "760.0665910454",
-          "nominalInterestRate": "0.1163086419",
-          "accruedInterest": "38.7363176236"
+          "notionalPrincipal": 760.0665910454,
+          "nominalInterestRate": 0.1163086419,
+          "accruedInterest": 38.7363176236
         },
         {
           "eventDate": "2014-11-01T00:00",
           "eventType": "IP",
-          "payoff": "38.7363176236",
+          "payoff": 38.7363176236,
           "currency": "USD",
-          "notionalPrincipal": "760.0665910454",
-          "nominalInterestRate": "0.1163086419",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 760.0665910454,
+          "nominalInterestRate": 0.1163086419,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-12-01T00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "760.0665910454",
-          "nominalInterestRate": "0.1185308641",
-          "accruedInterest": "7.2659435355"
+          "notionalPrincipal": 760.0665910454,
+          "nominalInterestRate": 0.1185308641,
+          "accruedInterest": 7.2659435355
         },
         {
           "eventDate": "2015-02-01T00:00",
           "eventType": "PR",
-          "payoff": "577.4308682649",
+          "payoff": 577.4308682649,
           "currency": "USD",
-          "notionalPrincipal": "182.6357227805",
-          "nominalInterestRate": "0.1185308641",
-          "accruedInterest": "22.569131735"
+          "notionalPrincipal": 182.6357227805,
+          "nominalInterestRate": 0.1185308641,
+          "accruedInterest": 22.569131735
         },
         {
           "eventDate": "2015-02-01T00:00",
           "eventType": "IP",
-          "payoff": "22.569131735",
+          "payoff": 22.569131735,
           "currency": "USD",
-          "notionalPrincipal": "182.6357227805",
-          "nominalInterestRate": "0.1185308641",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 182.6357227805,
+          "nominalInterestRate": 0.1185308641,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2015-05-01T00:00",
           "eventType": "IP",
-          "payoff": "5.2785461228",
+          "payoff": 5.2785461228,
           "currency": "USD",
-          "notionalPrincipal": "182.6357227805",
-          "nominalInterestRate": "0.1185308641",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 182.6357227805,
+          "nominalInterestRate": 0.1185308641,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2015-05-01T00:00",
           "eventType": "MD",
-          "payoff": "182.6357227805",
+          "payoff": 182.6357227805,
           "currency": "USD",
-          "notionalPrincipal": "0.0",
-          "nominalInterestRate": "0.1185308641",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 0.0,
+          "nominalInterestRate": 0.1185308641,
+          "accruedInterest": 0.0
         }
       ]
     },
@@ -7387,290 +7387,290 @@
         {
           "eventDate": "2013-01-01T00:00:00",
           "eventType": "IED",
-          "payoff": "-5000.0",
+          "payoff": -5000.0,
           "currency": "USD",
-          "notionalPrincipal": "5000.0",
-          "nominalInterestRate": "0.08",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 5000.0,
+          "nominalInterestRate": 0.08,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-04-01T00:00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "5000.0",
-          "nominalInterestRate": "0.1105679012345679",
-          "accruedInterest": "98.63013698630137"
+          "notionalPrincipal": 5000.0,
+          "nominalInterestRate": 0.1105679012345679,
+          "accruedInterest": 98.63013698630137
         },
         {
           "eventDate": "2013-07-01T00:00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "5000.0",
-          "nominalInterestRate": "0.11167901234567901",
-          "accruedInterest": "236.46135633350247"
+          "notionalPrincipal": 5000.0,
+          "nominalInterestRate": 0.11167901234567901,
+          "accruedInterest": 236.46135633350247
         },
         {
           "eventDate": "2013-09-01T00:00:00",
           "eventType": "IPCI",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "5331.31202435312",
-          "nominalInterestRate": "0.11167901234567901",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 5331.31202435312,
+          "nominalInterestRate": 0.11167901234567901,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-10-01T00:00:00",
           "eventType": "PR",
-          "payoff": "451.0633702970083",
+          "payoff": 451.0633702970083,
           "currency": "USD",
-          "notionalPrincipal": "4880.248654056112",
-          "nominalInterestRate": "0.11167901234567901",
-          "accruedInterest": "48.9366297029917"
+          "notionalPrincipal": 4880.248654056112,
+          "nominalInterestRate": 0.11167901234567901,
+          "accruedInterest": 48.9366297029917
         },
         {
           "eventDate": "2013-10-01T00:00:00",
           "eventType": "IP",
-          "payoff": "48.9366297029917",
+          "payoff": 48.9366297029917,
           "currency": "USD",
-          "notionalPrincipal": "4880.248654056112",
-          "nominalInterestRate": "0.11167901234567901",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4880.248654056112,
+          "nominalInterestRate": 0.11167901234567901,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-10-01T00:00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "4880.248654056112",
-          "nominalInterestRate": "0.1127901234567901",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4880.248654056112,
+          "nominalInterestRate": 0.1127901234567901,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-11-01T00:00:00",
           "eventType": "PR",
-          "payoff": "453.2499745372178",
+          "payoff": 453.2499745372178,
           "currency": "USD",
-          "notionalPrincipal": "4426.998679518894",
-          "nominalInterestRate": "0.1127901234567901",
-          "accruedInterest": "46.75002546278219"
+          "notionalPrincipal": 4426.998679518894,
+          "nominalInterestRate": 0.1127901234567901,
+          "accruedInterest": 46.75002546278219
         },
         {
           "eventDate": "2013-11-01T00:00:00",
           "eventType": "IP",
-          "payoff": "46.75002546278219",
+          "payoff": 46.75002546278219,
           "currency": "USD",
-          "notionalPrincipal": "4426.998679518894",
-          "nominalInterestRate": "0.1127901234567901",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 4426.998679518894,
+          "nominalInterestRate": 0.1127901234567901,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2013-12-01T00:00:00",
           "eventType": "PR",
-          "payoff": "458.9598580049877",
+          "payoff": 458.9598580049877,
           "currency": "USD",
-          "notionalPrincipal": "3968.0388215139064",
-          "nominalInterestRate": "0.1127901234567901",
-          "accruedInterest": "41.040141995012284"
+          "notionalPrincipal": 3968.0388215139064,
+          "nominalInterestRate": 0.1127901234567901,
+          "accruedInterest": 41.040141995012284
         },
         {
           "eventDate": "2013-12-01T00:00:00",
           "eventType": "IP",
-          "payoff": "41.040141995012284",
+          "payoff": 41.040141995012284,
           "currency": "USD",
-          "notionalPrincipal": "3968.0388215139064",
-          "nominalInterestRate": "0.1127901234567901",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 3968.0388215139064,
+          "nominalInterestRate": 0.1127901234567901,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-01-01T00:00:00",
           "eventType": "PR",
-          "payoff": "461.9884294647765",
+          "payoff": 461.9884294647765,
           "currency": "USD",
-          "notionalPrincipal": "3506.05039204913",
-          "nominalInterestRate": "0.1127901234567901",
-          "accruedInterest": "38.01157053522348"
+          "notionalPrincipal": 3506.05039204913,
+          "nominalInterestRate": 0.1127901234567901,
+          "accruedInterest": 38.01157053522348
         },
         {
           "eventDate": "2014-01-01T00:00:00",
           "eventType": "IP",
-          "payoff": "38.01157053522348",
+          "payoff": 38.01157053522348,
           "currency": "USD",
-          "notionalPrincipal": "3506.05039204913",
-          "nominalInterestRate": "0.1127901234567901",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 3506.05039204913,
+          "nominalInterestRate": 0.1127901234567901,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-01-01T00:00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "3506.05039204913",
-          "nominalInterestRate": "0.1139012345679012",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 3506.05039204913,
+          "nominalInterestRate": 0.1139012345679012,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-02-01T00:00:00",
           "eventType": "PR",
-          "payoff": "466.0831575028445",
+          "payoff": 466.0831575028445,
           "currency": "USD",
-          "notionalPrincipal": "3039.9672345462855",
-          "nominalInterestRate": "0.1139012345679012",
-          "accruedInterest": "33.91684249715553"
+          "notionalPrincipal": 3039.9672345462855,
+          "nominalInterestRate": 0.1139012345679012,
+          "accruedInterest": 33.91684249715553
         },
         {
           "eventDate": "2014-02-01T00:00:00",
           "eventType": "IP",
-          "payoff": "33.91684249715553",
+          "payoff": 33.91684249715553,
           "currency": "USD",
-          "notionalPrincipal": "3039.9672345462855",
-          "nominalInterestRate": "0.1139012345679012",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 3039.9672345462855,
+          "nominalInterestRate": 0.1139012345679012,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-03-01T00:00:00",
           "eventType": "PR",
-          "payoff": "473.4378942747887",
+          "payoff": 473.4378942747887,
           "currency": "USD",
-          "notionalPrincipal": "2566.529340271497",
-          "nominalInterestRate": "0.1139012345679012",
-          "accruedInterest": "26.562105725211318"
+          "notionalPrincipal": 2566.529340271497,
+          "nominalInterestRate": 0.1139012345679012,
+          "accruedInterest": 26.562105725211318
         },
         {
           "eventDate": "2014-03-01T00:00:00",
           "eventType": "IP",
-          "payoff": "26.562105725211318",
+          "payoff": 26.562105725211318,
           "currency": "USD",
-          "notionalPrincipal": "2566.529340271497",
-          "nominalInterestRate": "0.1139012345679012",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 2566.529340271497,
+          "nominalInterestRate": 0.1139012345679012,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-04-01T00:00:00",
           "eventType": "PR",
-          "payoff": "475.17189952668053",
+          "payoff": 475.17189952668053,
           "currency": "USD",
-          "notionalPrincipal": "2091.3574407448164",
-          "nominalInterestRate": "0.1139012345679012",
-          "accruedInterest": "24.828100473319452"
+          "notionalPrincipal": 2091.3574407448164,
+          "nominalInterestRate": 0.1139012345679012,
+          "accruedInterest": 24.828100473319452
         },
         {
           "eventDate": "2014-04-01T00:00:00",
           "eventType": "IP",
-          "payoff": "24.828100473319452",
+          "payoff": 24.828100473319452,
           "currency": "USD",
-          "notionalPrincipal": "2091.3574407448164",
-          "nominalInterestRate": "0.1139012345679012",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 2091.3574407448164,
+          "nominalInterestRate": 0.1139012345679012,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-04-01T00:00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "2091.3574407448164",
-          "nominalInterestRate": "0.1150123456790123",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 2091.3574407448164,
+          "nominalInterestRate": 0.1150123456790123,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-05-01T00:00:00",
           "eventType": "PR",
-          "payoff": "480.2302527468506",
+          "payoff": 480.2302527468506,
           "currency": "USD",
-          "notionalPrincipal": "1611.1271879979658",
-          "nominalInterestRate": "0.1150123456790123",
-          "accruedInterest": "19.769747253149365"
+          "notionalPrincipal": 1611.1271879979658,
+          "nominalInterestRate": 0.1150123456790123,
+          "accruedInterest": 19.769747253149365
         },
         {
           "eventDate": "2014-05-01T00:00:00",
           "eventType": "IP",
-          "payoff": "19.769747253149365",
+          "payoff": 19.769747253149365,
           "currency": "USD",
-          "notionalPrincipal": "1611.1271879979658",
-          "nominalInterestRate": "0.1150123456790123",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 1611.1271879979658,
+          "nominalInterestRate": 0.1150123456790123,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-06-01T00:00:00",
           "eventType": "PR",
-          "payoff": "484.26223279604056",
+          "payoff": 484.26223279604056,
           "currency": "USD",
-          "notionalPrincipal": "1126.8649552019253",
-          "nominalInterestRate": "0.1150123456790123",
-          "accruedInterest": "15.737767203959425"
+          "notionalPrincipal": 1126.8649552019253,
+          "nominalInterestRate": 0.1150123456790123,
+          "accruedInterest": 15.737767203959425
         },
         {
           "eventDate": "2014-06-01T00:00:00",
           "eventType": "IP",
-          "payoff": "15.737767203959425",
+          "payoff": 15.737767203959425,
           "currency": "USD",
-          "notionalPrincipal": "1126.8649552019253",
-          "nominalInterestRate": "0.1150123456790123",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 1126.8649552019253,
+          "nominalInterestRate": 0.1150123456790123,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-07-01T00:00:00",
           "eventType": "PR",
-          "payoff": "489.3476672525001",
+          "payoff": 489.3476672525001,
           "currency": "USD",
-          "notionalPrincipal": "637.5172879494253",
-          "nominalInterestRate": "0.1150123456790123",
-          "accruedInterest": "10.65233274749988"
+          "notionalPrincipal": 637.5172879494253,
+          "nominalInterestRate": 0.1150123456790123,
+          "accruedInterest": 10.65233274749988
         },
         {
           "eventDate": "2014-07-01T00:00:00",
           "eventType": "IP",
-          "payoff": "10.65233274749988",
+          "payoff": 10.65233274749988,
           "currency": "USD",
-          "notionalPrincipal": "637.5172879494253",
-          "nominalInterestRate": "0.1150123456790123",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 637.5172879494253,
+          "nominalInterestRate": 0.1150123456790123,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-07-01T00:00:00",
           "eventType": "RR",
-          "payoff": "0.0",
+          "payoff": 0.0,
           "currency": "USD",
-          "notionalPrincipal": "637.5172879494253",
-          "nominalInterestRate": "0.1161234567901234",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 637.5172879494253,
+          "nominalInterestRate": 0.1161234567901234,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-08-01T00:00:00",
           "eventType": "PR",
-          "payoff": "493.7124601412474",
+          "payoff": 493.7124601412474,
           "currency": "USD",
-          "notionalPrincipal": "143.8048278081779",
-          "nominalInterestRate": "0.1161234567901234",
-          "accruedInterest": "6.287539858752614"
+          "notionalPrincipal": 143.8048278081779,
+          "nominalInterestRate": 0.1161234567901234,
+          "accruedInterest": 6.287539858752614
         },
         {
           "eventDate": "2014-08-01T00:00:00",
           "eventType": "IP",
-          "payoff": "6.287539858752614",
+          "payoff": 6.287539858752614,
           "currency": "USD",
-          "notionalPrincipal": "143.8048278081779",
-          "nominalInterestRate": "0.1161234567901234",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 143.8048278081779,
+          "nominalInterestRate": 0.1161234567901234,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-09-01T00:00:00",
           "eventType": "IP",
-          "payoff": "1.4182808902849766",
+          "payoff": 1.4182808902849766,
           "currency": "USD",
-          "notionalPrincipal": "143.8048278081779",
-          "nominalInterestRate": "0.1161234567901234",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 143.8048278081779,
+          "nominalInterestRate": 0.1161234567901234,
+          "accruedInterest": 0.0
         },
         {
           "eventDate": "2014-09-01T00:00:00",
           "eventType": "MD",
-          "payoff": "143.8048278081779",
+          "payoff": 143.8048278081779,
           "currency": "USD",
-          "notionalPrincipal": "0.0",
-          "nominalInterestRate": "0.1161234567901234",
-          "accruedInterest": "0.0"
+          "notionalPrincipal": 0.0,
+          "nominalInterestRate": 0.1161234567901234,
+          "accruedInterest": 0.0
         }
       ]
     }


### PR DESCRIPTION
In the JSON files the types in the _results_ are not consistent. _payoff_, _notionalPrincipal_, _nominalInterestRate_ and _accruedInterest_ are in some cases of type string and in other cases of type number within the same file. I converted the string occurrences to numbers for the NAM and ANN test-cases (PAM and LAM are fine).

Thanks! 